### PR TITLE
fsharp.data.adaptive added to benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,53 +79,62 @@ AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
   DefaultJob : .NET Core 3.1.0 (CoreCLR 4.700.19.56402, CoreFX 4.700.19.56404), X64 RyuJIT
 
 
-|                           Method | CollectionSize |        Mean |    Error |   StdDev |
-|--------------------------------- |--------------- |------------:|---------:|---------:|
-|                       GetHashMap |             10 |    11.29 ns | 0.018 ns | 0.017 ns |
-|                GetImToolsHashMap |             10 |    28.15 ns | 0.192 ns | 0.180 ns |
-|                     GetFSharpMap |             10 |    41.07 ns | 0.589 ns | 0.551 ns |
-|                GetFSharpXHashMap |             10 |    99.36 ns | 1.614 ns | 1.510 ns |
-| GetSystemCollectionsImmutableMap |             10 |    26.49 ns | 0.106 ns | 0.099 ns |
-|                       GetHashMap |            100 |    13.04 ns | 0.014 ns | 0.013 ns |
-|                GetImToolsHashMap |            100 |    42.63 ns | 0.841 ns | 1.233 ns |
-|                     GetFSharpMap |            100 |    73.12 ns | 1.456 ns | 1.496 ns |
-|                GetFSharpXHashMap |            100 |   112.69 ns | 1.623 ns | 1.518 ns |
-| GetSystemCollectionsImmutableMap |            100 |    37.03 ns | 0.255 ns | 0.239 ns |
-|                       GetHashMap |           1000 |    11.45 ns | 0.003 ns | 0.003 ns |
-|                GetImToolsHashMap |           1000 |    64.82 ns | 0.234 ns | 0.219 ns |
-|                     GetFSharpMap |           1000 |   102.40 ns | 2.037 ns | 2.501 ns |
-|                GetFSharpXHashMap |           1000 |   117.86 ns | 1.863 ns | 1.743 ns |
-| GetSystemCollectionsImmutableMap |           1000 |    53.08 ns | 0.141 ns | 0.132 ns |
-|                       GetHashMap |         100000 |    23.63 ns | 0.024 ns | 0.023 ns |
-|                GetImToolsHashMap |         100000 |   200.21 ns | 0.206 ns | 0.193 ns |
-|                     GetFSharpMap |         100000 |   194.06 ns | 1.847 ns | 1.728 ns |
-|                GetFSharpXHashMap |         100000 |   146.31 ns | 1.354 ns | 1.267 ns |
-| GetSystemCollectionsImmutableMap |         100000 |   142.89 ns | 0.068 ns | 0.063 ns |
-|                       GetHashMap |         500000 |    70.05 ns | 0.044 ns | 0.039 ns |
-|                GetImToolsHashMap |         500000 |   509.51 ns | 0.317 ns | 0.281 ns |
-|                     GetFSharpMap |         500000 |   328.15 ns | 1.467 ns | 1.372 ns |
-|                GetFSharpXHashMap |         500000 |   233.56 ns | 1.059 ns | 0.990 ns |
-| GetSystemCollectionsImmutableMap |         500000 |   322.57 ns | 0.777 ns | 0.726 ns |
-|                       GetHashMap |         750000 |    96.93 ns | 0.360 ns | 0.337 ns |
-|                GetImToolsHashMap |         750000 |   629.03 ns | 0.378 ns | 0.315 ns |
-|                     GetFSharpMap |         750000 |   413.14 ns | 3.738 ns | 3.496 ns |
-|                GetFSharpXHashMap |         750000 |   355.23 ns | 0.783 ns | 0.694 ns |
-| GetSystemCollectionsImmutableMap |         750000 |   411.91 ns | 0.292 ns | 0.244 ns |
-|                       GetHashMap |        1000000 |   105.36 ns | 0.053 ns | 0.047 ns |
-|                GetImToolsHashMap |        1000000 |   694.33 ns | 0.368 ns | 0.344 ns |
-|                     GetFSharpMap |        1000000 |   470.99 ns | 4.005 ns | 3.127 ns |
-|                GetFSharpXHashMap |        1000000 |   333.83 ns | 0.449 ns | 0.420 ns |
-| GetSystemCollectionsImmutableMap |        1000000 |   480.34 ns | 1.495 ns | 1.325 ns |
-|                       GetHashMap |        5000000 |   134.20 ns | 0.136 ns | 0.127 ns |
-|                GetImToolsHashMap |        5000000 | 1,286.32 ns | 3.662 ns | 3.426 ns |
-|                     GetFSharpMap |        5000000 |   834.56 ns | 5.437 ns | 5.086 ns |
-|                GetFSharpXHashMap |        5000000 |   377.85 ns | 3.815 ns | 3.186 ns |
-| GetSystemCollectionsImmutableMap |        5000000 |   872.64 ns | 7.665 ns | 7.170 ns |
-|                       GetHashMap |       10000000 |   155.14 ns | 1.077 ns | 1.007 ns |
-|                GetImToolsHashMap |       10000000 | 1,573.52 ns | 4.160 ns | 3.891 ns |
-|                     GetFSharpMap |       10000000 | 1,042.60 ns | 5.229 ns | 4.891 ns |
-|                GetFSharpXHashMap |       10000000 |   410.99 ns | 1.255 ns | 1.174 ns |
-| GetSystemCollectionsImmutableMap |       10000000 | 1,011.88 ns | 4.027 ns | 3.363 ns |
+|                           Method | CollectionSize |        Mean |    Error |   StdDev |      Median |
+|--------------------------------- |--------------- |------------:|---------:|---------:|------------:|
+|                       GetHashMap |             10 |    11.00 ns | 0.073 ns | 0.069 ns |    10.96 ns |
+|                GetImToolsHashMap |             10 |    29.02 ns | 0.536 ns | 0.501 ns |    29.09 ns |
+|                     GetFSharpMap |             10 |    41.20 ns | 0.801 ns | 0.823 ns |    41.37 ns |
+|                GetFSharpXHashMap |             10 |   101.17 ns | 1.945 ns | 1.819 ns |   101.39 ns |
+| GetSystemCollectionsImmutableMap |             10 |    24.58 ns | 0.071 ns | 0.055 ns |    24.60 ns |
+|         GetFSharpDataAdaptiveMap |             10 |    21.83 ns | 0.020 ns | 0.019 ns |    21.82 ns |
+|                       GetHashMap |            100 |    13.31 ns | 0.019 ns | 0.017 ns |    13.31 ns |
+|                GetImToolsHashMap |            100 |    40.64 ns | 0.458 ns | 0.428 ns |    40.88 ns |
+|                     GetFSharpMap |            100 |    73.72 ns | 1.434 ns | 1.342 ns |    73.72 ns |
+|                GetFSharpXHashMap |            100 |   108.59 ns | 1.023 ns | 0.957 ns |   108.46 ns |
+| GetSystemCollectionsImmutableMap |            100 |    36.85 ns | 0.251 ns | 0.235 ns |    36.93 ns |
+|         GetFSharpDataAdaptiveMap |            100 |    43.33 ns | 0.010 ns | 0.009 ns |    43.33 ns |
+|                       GetHashMap |           1000 |    11.32 ns | 0.038 ns | 0.035 ns |    11.30 ns |
+|                GetImToolsHashMap |           1000 |    66.25 ns | 1.268 ns | 1.604 ns |    65.30 ns |
+|                     GetFSharpMap |           1000 |   108.31 ns | 0.645 ns | 0.539 ns |   108.33 ns |
+|                GetFSharpXHashMap |           1000 |   113.16 ns | 1.001 ns | 0.936 ns |   113.65 ns |
+| GetSystemCollectionsImmutableMap |           1000 |    53.02 ns | 0.099 ns | 0.093 ns |    53.04 ns |
+|         GetFSharpDataAdaptiveMap |           1000 |    65.17 ns | 0.326 ns | 0.305 ns |    65.31 ns |
+|                       GetHashMap |         100000 |    23.24 ns | 0.035 ns | 0.033 ns |    23.24 ns |
+|                GetImToolsHashMap |         100000 |   199.14 ns | 0.453 ns | 0.402 ns |   199.04 ns |
+|                     GetFSharpMap |         100000 |   198.27 ns | 1.502 ns | 1.405 ns |   197.49 ns |
+|                GetFSharpXHashMap |         100000 |   144.64 ns | 1.134 ns | 1.061 ns |   144.78 ns |
+| GetSystemCollectionsImmutableMap |         100000 |   143.96 ns | 0.092 ns | 0.086 ns |   143.93 ns |
+|         GetFSharpDataAdaptiveMap |         100000 |   141.12 ns | 0.051 ns | 0.043 ns |   141.11 ns |
+|                       GetHashMap |         500000 |    69.74 ns | 0.181 ns | 0.160 ns |    69.80 ns |
+|                GetImToolsHashMap |         500000 |   511.80 ns | 1.380 ns | 1.291 ns |   511.30 ns |
+|                     GetFSharpMap |         500000 |   303.07 ns | 3.629 ns | 3.394 ns |   301.08 ns |
+|                GetFSharpXHashMap |         500000 |   229.01 ns | 0.802 ns | 0.711 ns |   229.16 ns |
+| GetSystemCollectionsImmutableMap |         500000 |   319.15 ns | 1.387 ns | 1.298 ns |   318.45 ns |
+|         GetFSharpDataAdaptiveMap |         500000 |   303.75 ns | 0.156 ns | 0.146 ns |   303.77 ns |
+|                       GetHashMap |         750000 |    99.19 ns | 0.189 ns | 0.167 ns |    99.19 ns |
+|                GetImToolsHashMap |         750000 |   617.97 ns | 1.185 ns | 1.109 ns |   618.14 ns |
+|                     GetFSharpMap |         750000 |   405.86 ns | 7.103 ns | 6.644 ns |   404.11 ns |
+|                GetFSharpXHashMap |         750000 |   351.62 ns | 0.796 ns | 0.745 ns |   351.69 ns |
+| GetSystemCollectionsImmutableMap |         750000 |   407.29 ns | 0.302 ns | 0.283 ns |   407.26 ns |
+|         GetFSharpDataAdaptiveMap |         750000 |   348.77 ns | 0.198 ns | 0.175 ns |   348.73 ns |
+|                       GetHashMap |        1000000 |   106.21 ns | 0.156 ns | 0.130 ns |   106.17 ns |
+|                GetImToolsHashMap |        1000000 |   716.39 ns | 0.497 ns | 0.415 ns |   716.42 ns |
+|                     GetFSharpMap |        1000000 |   465.08 ns | 8.363 ns | 7.823 ns |   468.86 ns |
+|                GetFSharpXHashMap |        1000000 |   346.15 ns | 0.614 ns | 0.545 ns |   346.10 ns |
+| GetSystemCollectionsImmutableMap |        1000000 |   472.67 ns | 2.598 ns | 2.430 ns |   471.20 ns |
+|         GetFSharpDataAdaptiveMap |        1000000 |   392.68 ns | 1.090 ns | 0.966 ns |   392.89 ns |
+|                       GetHashMap |        5000000 |   134.10 ns | 0.031 ns | 0.026 ns |   134.10 ns |
+|                GetImToolsHashMap |        5000000 | 1,263.54 ns | 0.581 ns | 0.515 ns | 1,263.49 ns |
+|                     GetFSharpMap |        5000000 |   839.73 ns | 0.659 ns | 0.617 ns |   839.72 ns |
+|                GetFSharpXHashMap |        5000000 |   379.43 ns | 1.143 ns | 1.070 ns |   379.46 ns |
+| GetSystemCollectionsImmutableMap |        5000000 |   880.08 ns | 0.462 ns | 0.409 ns |   880.12 ns |
+|         GetFSharpDataAdaptiveMap |        5000000 |   610.11 ns | 0.837 ns | 0.783 ns |   609.90 ns |
+|                       GetHashMap |       10000000 |   149.55 ns | 0.029 ns | 0.026 ns |   149.54 ns |
+|                GetImToolsHashMap |       10000000 | 1,538.42 ns | 0.990 ns | 0.877 ns | 1,538.37 ns |
+|                     GetFSharpMap |       10000000 | 1,024.58 ns | 1.056 ns | 0.988 ns | 1,024.54 ns |
+|                GetFSharpXHashMap |       10000000 |   384.30 ns | 0.744 ns | 0.696 ns |   384.38 ns |
+| GetSystemCollectionsImmutableMap |       10000000 | 1,031.06 ns | 0.547 ns | 0.511 ns | 1,031.02 ns |
+|         GetFSharpDataAdaptiveMap |       10000000 |   705.51 ns | 0.449 ns | 0.398 ns |   705.42 ns |
 ```
 
 ## Design decisions that may affect consumers of this library

--- a/test/FSharp.HashCollections.Benchmarks/BenchmarkProgram.fs
+++ b/test/FSharp.HashCollections.Benchmarks/BenchmarkProgram.fs
@@ -1,4 +1,4 @@
-﻿module Program 
+﻿module Program
 
 open System
 open FSharp.HashCollections
@@ -7,16 +7,18 @@ open BenchmarkDotNet.Running
 open FSharpx.Collections
 open ImTools
 
-module Constants = 
+module Constants =
     let [<Literal>] OperationsPerInvokeInt = 100000
 
-type ReadBenchmarks() = 
+type ReadBenchmarks() =
 
     let mutable hashMapData = HashMap.empty
     let mutable imToolsMap = ImTools.ImHashMap.Empty
     let mutable fsharpMapData = Map.empty
     let mutable fsharpXHashMap = FSharpx.Collections.PersistentHashMap.empty
     let mutable systemImmutableMap = System.Collections.Immutable.ImmutableDictionary.Empty
+    let mutable fsharpDataAdaptiveMap = FSharp.Data.Adaptive.HashMap.Empty
+
     let mutable keyToLookup = Array.zeroCreate Constants.OperationsPerInvokeInt
     let mutable dummyBufferVOption = Array.zeroCreate Constants.OperationsPerInvokeInt
     let mutable dummyBufferOption = Array.zeroCreate Constants.OperationsPerInvokeInt
@@ -25,55 +27,62 @@ type ReadBenchmarks() =
 
     [<Params(10, 100, 1000, 100_000, 500_000, 750_000, 1_000_000, 5_000_000, 10_000_000)>]
     member val public CollectionSize = 0 with get, set
-    
-    member this.SetupKeyToLookup() = 
+
+    member this.SetupKeyToLookup() =
         for i = 0 to keyToLookup.Length - 1 do
             keyToLookup.[i] <- randomGen.Next(0, this.CollectionSize)
 
     [<GlobalSetup(Target = "GetHashMap")>]
-    member this.SetupHashMapData() = 
-        hashMapData <- HashMap.empty        
+    member this.SetupHashMapData() =
+        hashMapData <- HashMap.empty
         for i = 0 to this.CollectionSize - 1 do
             hashMapData <- hashMapData |> HashMap.add i i
         this.SetupKeyToLookup()
 
     [<GlobalSetup(Target = "GetImToolsHashMap")>]
-    member this.SetupImToolsHashMapData() = 
+    member this.SetupImToolsHashMapData() =
         imToolsMap <- ImTools.ImHashMap.Empty
         for i = 0 to this.CollectionSize - 1 do
             imToolsMap <- imToolsMap.AddOrUpdate(i, i)
         this.SetupKeyToLookup()
 
     [<GlobalSetup(Target = "GetFSharpMap")>]
-    member this.SetupFSharpMapData() = 
-        fsharpMapData <- Map.empty        
+    member this.SetupFSharpMapData() =
+        fsharpMapData <- Map.empty
         for i = 0 to this.CollectionSize - 1 do
             fsharpMapData <- fsharpMapData |> Map.add i i
         this.SetupKeyToLookup()
 
     [<GlobalSetup(Target = "GetFSharpXHashMap")>]
-    member this.SetupFSharpXMapData() = 
-        fsharpXHashMap <- FSharpx.Collections.PersistentHashMap.empty        
+    member this.SetupFSharpXMapData() =
+        fsharpXHashMap <- FSharpx.Collections.PersistentHashMap.empty
         for i = 0 to this.CollectionSize - 1 do
             fsharpXHashMap <- fsharpXHashMap |> FSharpx.Collections.PersistentHashMap.add i i
-        this.SetupKeyToLookup() 
+        this.SetupKeyToLookup()
 
     [<GlobalSetup(Target = "GetSystemCollectionsImmutableMap")>]
-    member this.SetupSystemCollectionsImmutableMapData() = 
-        systemImmutableMap <- System.Collections.Immutable.ImmutableDictionary.Empty 
+    member this.SetupSystemCollectionsImmutableMapData() =
+        systemImmutableMap <- System.Collections.Immutable.ImmutableDictionary.Empty
         for i = 0 to this.CollectionSize - 1 do
             systemImmutableMap <- systemImmutableMap.Add(i, i)
-        this.SetupKeyToLookup()  
+        this.SetupKeyToLookup()
+
+    [<GlobalSetup(Target = "GetFSharpDataAdaptiveMap")>]
+    member this.SetupFSharpDataAdaptiveMapData() =
+        fsharpDataAdaptiveMap <- FSharp.Data.Adaptive.HashMap.Empty
+        for i = 0 to this.CollectionSize - 1 do
+            fsharpDataAdaptiveMap <- fsharpDataAdaptiveMap.Add(i, i)
+        this.SetupKeyToLookup()
 
     [<Benchmark(OperationsPerInvoke = Constants.OperationsPerInvokeInt)>]
-    member _.GetHashMap() = 
+    member _.GetHashMap() =
         let mutable i = 0
         for k in keyToLookup do
             dummyBufferVOption.[i] <- hashMapData |> HashMap.tryFind k
             i <- i + 1
 
     [<Benchmark(OperationsPerInvoke = Constants.OperationsPerInvokeInt)>]
-    member _.GetImToolsHashMap() = 
+    member _.GetImToolsHashMap() =
         let mutable i = 0
         for k in keyToLookup do
             match imToolsMap.TryFind(k) with
@@ -82,27 +91,34 @@ type ReadBenchmarks() =
             i <- i + 1
 
     [<Benchmark(OperationsPerInvoke = Constants.OperationsPerInvokeInt)>]
-    member _.GetFSharpMap() = 
+    member _.GetFSharpMap() =
         let mutable i = 0
         for k in keyToLookup do
             dummyBufferOption.[i] <- fsharpMapData |> Map.tryFind k
             i <- i + 1
 
     [<Benchmark(OperationsPerInvoke = Constants.OperationsPerInvokeInt)>]
-    member _.GetFSharpXHashMap() = 
+    member _.GetFSharpXHashMap() =
         let mutable i = 0
         for k in keyToLookup do
             dummyBufferNoOption.[i] <- fsharpXHashMap |> FSharpx.Collections.PersistentHashMap.find k
             i <- i + 1
 
     [<Benchmark(OperationsPerInvoke = Constants.OperationsPerInvokeInt)>]
-    member _.GetSystemCollectionsImmutableMap() = 
+    member _.GetSystemCollectionsImmutableMap() =
         let mutable i = 0
         for k in keyToLookup do
             match systemImmutableMap.TryGetValue(k) with
             | (true, x) -> dummyBufferNoOption.[i] <- x
             | _ -> ()
-            i <- i + 1            
+            i <- i + 1
+
+    [<Benchmark(OperationsPerInvoke = Constants.OperationsPerInvokeInt)>]
+    member _.GetFSharpDataAdaptiveMap() =
+        let mutable i = 0
+        for k in keyToLookup do
+            dummyBufferVOption.[i] <- fsharpDataAdaptiveMap |> FSharp.Data.Adaptive.HashMap.tryFindV k
+            i <- i + 1
 
 [<EntryPoint>]
 let main argv =

--- a/test/FSharp.HashCollections.Benchmarks/FSharp.HashCollections.Benchmarks.fsproj
+++ b/test/FSharp.HashCollections.Benchmarks/FSharp.HashCollections.Benchmarks.fsproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+    <PackageReference Include="FSharp.Data.Adaptive" Version="0.0.13" />
     <PackageReference Include="FSharpX.Collections" Version="2.1.2" />
     <PackageReference Include="ImTools.dll" Version="1.0.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />


### PR DESCRIPTION
Comparing FSharp.Data.Adaptive performance to my implementation to see whether it is worthwhile pushing this library forward.

Benchmark Results with just the two collections shows this repo to be significantly faster than FSharp.Data.Adaptive for the lookup case.

```
BenchmarkDotNet=v0.12.0, OS=arch 
AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.100
  [Host]     : .NET Core 3.1.0 (CoreCLR 4.700.19.56402, CoreFX 4.700.19.56404), X64 RyuJIT DEBUG
  DefaultJob : .NET Core 3.1.0 (CoreCLR 4.700.19.56402, CoreFX 4.700.19.56404), X64 RyuJIT


|                   Method | CollectionSize |      Mean |    Error |   StdDev |
|------------------------- |--------------- |----------:|---------:|---------:|
|               GetHashMap |             10 |  11.07 ns | 0.023 ns | 0.022 ns |
| GetFSharpDataAdaptiveMap |             10 |  21.05 ns | 0.024 ns | 0.021 ns |
|               GetHashMap |            100 |  13.17 ns | 0.011 ns | 0.010 ns |
| GetFSharpDataAdaptiveMap |            100 |  43.17 ns | 0.091 ns | 0.085 ns |
|               GetHashMap |           1000 |  11.16 ns | 0.013 ns | 0.013 ns |
| GetFSharpDataAdaptiveMap |           1000 |  65.02 ns | 0.043 ns | 0.038 ns |
|               GetHashMap |         100000 |  23.24 ns | 0.022 ns | 0.021 ns |
| GetFSharpDataAdaptiveMap |         100000 | 140.15 ns | 2.027 ns | 1.797 ns |
|               GetHashMap |         500000 |  69.15 ns | 1.056 ns | 0.936 ns |
| GetFSharpDataAdaptiveMap |         500000 | 302.25 ns | 1.888 ns | 1.766 ns |
|               GetHashMap |         750000 |  98.61 ns | 0.074 ns | 0.062 ns |
| GetFSharpDataAdaptiveMap |         750000 | 352.38 ns | 0.350 ns | 0.311 ns |
|               GetHashMap |        1000000 | 109.27 ns | 0.044 ns | 0.041 ns |
| GetFSharpDataAdaptiveMap |        1000000 | 399.60 ns | 7.830 ns | 6.941 ns |
|               GetHashMap |        5000000 | 133.62 ns | 1.209 ns | 1.131 ns |
| GetFSharpDataAdaptiveMap |        5000000 | 610.57 ns | 3.078 ns | 2.880 ns |
|               GetHashMap |       10000000 | 151.67 ns | 0.146 ns | 0.129 ns |
| GetFSharpDataAdaptiveMap |       10000000 | 705.60 ns | 1.254 ns | 1.173 ns |
```