### PR TITLE
Lower equality reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,16 @@ let hashMapResult = HashSet.empty |> HashSet.add k |> HashSet.contains k // Resu
 
 ## Equality customisation
 
-All collections allow custom equality to be assigned if required. The equality is encoded as a type on the collection so equality and hashing operations are consistent. Same collection types with different equality comparers can not be used interchangeably by operations provided.  To use:
+By default any "empty" seeded HashSet/Map uses F# HashIdentity.Structural comparison to determine equality and calculate hashcodes. This is in line with the F# collection types.
+
+In addition all collection types allow custom equality to be assigned if required. The equality is encoded as a type on the collection so equality and hashing operations are consistent. Same collection types with different equality comparers can not be used interchangeably by operations provided.  To use:
 
 ```
 // Uses the default equality template provided.
-let defaultIntHashMap : HashMap<int, int64, StandardEqualityTemplate<int>> = HashMap.empty
+let defaultIntHashMap : HashMap<int, int64> = HashMap.empty
 
 // Uses a custom equality template provided by the type parameter.
-let defaultIntHashMap : HashMap<int, int64, CustomEqualityComparer> = HashMap.emptyWithComparer
+let customEqIntHashMap : HashMap<int, int64, CustomEqualityComparer> = HashMap.emptyWithComparer
 ```
 
 Any equality comparer specified in the type signature must:
@@ -69,6 +71,8 @@ Any equality comparer specified in the type signature must:
 
 Keys are of type int32 where "GetHashMap" represents this library's HashMap collection.
 
+All are using F# HashIdentity.Structural comparison.
+
 ```
 // * Summary *
 
@@ -79,62 +83,62 @@ AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
   DefaultJob : .NET Core 3.1.0 (CoreCLR 4.700.19.56402, CoreFX 4.700.19.56404), X64 RyuJIT
 
 
-|                           Method | CollectionSize |        Mean |    Error |   StdDev |      Median |
-|--------------------------------- |--------------- |------------:|---------:|---------:|------------:|
-|                       GetHashMap |             10 |    11.00 ns | 0.073 ns | 0.069 ns |    10.96 ns |
-|                GetImToolsHashMap |             10 |    29.02 ns | 0.536 ns | 0.501 ns |    29.09 ns |
-|                     GetFSharpMap |             10 |    41.20 ns | 0.801 ns | 0.823 ns |    41.37 ns |
-|                GetFSharpXHashMap |             10 |   101.17 ns | 1.945 ns | 1.819 ns |   101.39 ns |
-| GetSystemCollectionsImmutableMap |             10 |    24.58 ns | 0.071 ns | 0.055 ns |    24.60 ns |
-|         GetFSharpDataAdaptiveMap |             10 |    21.83 ns | 0.020 ns | 0.019 ns |    21.82 ns |
-|                       GetHashMap |            100 |    13.31 ns | 0.019 ns | 0.017 ns |    13.31 ns |
-|                GetImToolsHashMap |            100 |    40.64 ns | 0.458 ns | 0.428 ns |    40.88 ns |
-|                     GetFSharpMap |            100 |    73.72 ns | 1.434 ns | 1.342 ns |    73.72 ns |
-|                GetFSharpXHashMap |            100 |   108.59 ns | 1.023 ns | 0.957 ns |   108.46 ns |
-| GetSystemCollectionsImmutableMap |            100 |    36.85 ns | 0.251 ns | 0.235 ns |    36.93 ns |
-|         GetFSharpDataAdaptiveMap |            100 |    43.33 ns | 0.010 ns | 0.009 ns |    43.33 ns |
-|                       GetHashMap |           1000 |    11.32 ns | 0.038 ns | 0.035 ns |    11.30 ns |
-|                GetImToolsHashMap |           1000 |    66.25 ns | 1.268 ns | 1.604 ns |    65.30 ns |
-|                     GetFSharpMap |           1000 |   108.31 ns | 0.645 ns | 0.539 ns |   108.33 ns |
-|                GetFSharpXHashMap |           1000 |   113.16 ns | 1.001 ns | 0.936 ns |   113.65 ns |
-| GetSystemCollectionsImmutableMap |           1000 |    53.02 ns | 0.099 ns | 0.093 ns |    53.04 ns |
-|         GetFSharpDataAdaptiveMap |           1000 |    65.17 ns | 0.326 ns | 0.305 ns |    65.31 ns |
-|                       GetHashMap |         100000 |    23.24 ns | 0.035 ns | 0.033 ns |    23.24 ns |
-|                GetImToolsHashMap |         100000 |   199.14 ns | 0.453 ns | 0.402 ns |   199.04 ns |
-|                     GetFSharpMap |         100000 |   198.27 ns | 1.502 ns | 1.405 ns |   197.49 ns |
-|                GetFSharpXHashMap |         100000 |   144.64 ns | 1.134 ns | 1.061 ns |   144.78 ns |
-| GetSystemCollectionsImmutableMap |         100000 |   143.96 ns | 0.092 ns | 0.086 ns |   143.93 ns |
-|         GetFSharpDataAdaptiveMap |         100000 |   141.12 ns | 0.051 ns | 0.043 ns |   141.11 ns |
-|                       GetHashMap |         500000 |    69.74 ns | 0.181 ns | 0.160 ns |    69.80 ns |
-|                GetImToolsHashMap |         500000 |   511.80 ns | 1.380 ns | 1.291 ns |   511.30 ns |
-|                     GetFSharpMap |         500000 |   303.07 ns | 3.629 ns | 3.394 ns |   301.08 ns |
-|                GetFSharpXHashMap |         500000 |   229.01 ns | 0.802 ns | 0.711 ns |   229.16 ns |
-| GetSystemCollectionsImmutableMap |         500000 |   319.15 ns | 1.387 ns | 1.298 ns |   318.45 ns |
-|         GetFSharpDataAdaptiveMap |         500000 |   303.75 ns | 0.156 ns | 0.146 ns |   303.77 ns |
-|                       GetHashMap |         750000 |    99.19 ns | 0.189 ns | 0.167 ns |    99.19 ns |
-|                GetImToolsHashMap |         750000 |   617.97 ns | 1.185 ns | 1.109 ns |   618.14 ns |
-|                     GetFSharpMap |         750000 |   405.86 ns | 7.103 ns | 6.644 ns |   404.11 ns |
-|                GetFSharpXHashMap |         750000 |   351.62 ns | 0.796 ns | 0.745 ns |   351.69 ns |
-| GetSystemCollectionsImmutableMap |         750000 |   407.29 ns | 0.302 ns | 0.283 ns |   407.26 ns |
-|         GetFSharpDataAdaptiveMap |         750000 |   348.77 ns | 0.198 ns | 0.175 ns |   348.73 ns |
-|                       GetHashMap |        1000000 |   106.21 ns | 0.156 ns | 0.130 ns |   106.17 ns |
-|                GetImToolsHashMap |        1000000 |   716.39 ns | 0.497 ns | 0.415 ns |   716.42 ns |
-|                     GetFSharpMap |        1000000 |   465.08 ns | 8.363 ns | 7.823 ns |   468.86 ns |
-|                GetFSharpXHashMap |        1000000 |   346.15 ns | 0.614 ns | 0.545 ns |   346.10 ns |
-| GetSystemCollectionsImmutableMap |        1000000 |   472.67 ns | 2.598 ns | 2.430 ns |   471.20 ns |
-|         GetFSharpDataAdaptiveMap |        1000000 |   392.68 ns | 1.090 ns | 0.966 ns |   392.89 ns |
-|                       GetHashMap |        5000000 |   134.10 ns | 0.031 ns | 0.026 ns |   134.10 ns |
-|                GetImToolsHashMap |        5000000 | 1,263.54 ns | 0.581 ns | 0.515 ns | 1,263.49 ns |
-|                     GetFSharpMap |        5000000 |   839.73 ns | 0.659 ns | 0.617 ns |   839.72 ns |
-|                GetFSharpXHashMap |        5000000 |   379.43 ns | 1.143 ns | 1.070 ns |   379.46 ns |
-| GetSystemCollectionsImmutableMap |        5000000 |   880.08 ns | 0.462 ns | 0.409 ns |   880.12 ns |
-|         GetFSharpDataAdaptiveMap |        5000000 |   610.11 ns | 0.837 ns | 0.783 ns |   609.90 ns |
-|                       GetHashMap |       10000000 |   149.55 ns | 0.029 ns | 0.026 ns |   149.54 ns |
-|                GetImToolsHashMap |       10000000 | 1,538.42 ns | 0.990 ns | 0.877 ns | 1,538.37 ns |
-|                     GetFSharpMap |       10000000 | 1,024.58 ns | 1.056 ns | 0.988 ns | 1,024.54 ns |
-|                GetFSharpXHashMap |       10000000 |   384.30 ns | 0.744 ns | 0.696 ns |   384.38 ns |
-| GetSystemCollectionsImmutableMap |       10000000 | 1,031.06 ns | 0.547 ns | 0.511 ns | 1,031.02 ns |
-|         GetFSharpDataAdaptiveMap |       10000000 |   705.51 ns | 0.449 ns | 0.398 ns |   705.42 ns |
+|                           Method | CollectionSize |        Mean |    Error |   StdDev |
+|--------------------------------- |--------------- |------------:|---------:|---------:|
+|                       GetHashMap |             10 |    11.07 ns | 0.071 ns | 0.063 ns |
+|                GetImToolsHashMap |             10 |    28.52 ns | 0.203 ns | 0.190 ns |
+|                     GetFSharpMap |             10 |    39.55 ns | 0.540 ns | 0.505 ns |
+|                GetFSharpXHashMap |             10 |   103.17 ns | 1.195 ns | 1.118 ns |
+| GetSystemCollectionsImmutableMap |             10 |    24.38 ns | 0.318 ns | 0.298 ns |
+|         GetFSharpDataAdaptiveMap |             10 |    21.88 ns | 0.088 ns | 0.082 ns |
+|                       GetHashMap |            100 |    15.80 ns | 0.027 ns | 0.025 ns |
+|                GetImToolsHashMap |            100 |    42.50 ns | 0.831 ns | 0.816 ns |
+|                     GetFSharpMap |            100 |    70.69 ns | 1.385 ns | 1.595 ns |
+|                GetFSharpXHashMap |            100 |   114.97 ns | 1.520 ns | 1.422 ns |
+| GetSystemCollectionsImmutableMap |            100 |    36.47 ns | 0.349 ns | 0.327 ns |
+|         GetFSharpDataAdaptiveMap |            100 |    43.15 ns | 0.098 ns | 0.082 ns |
+|                       GetHashMap |           1000 |    12.83 ns | 0.017 ns | 0.014 ns |
+|                GetImToolsHashMap |           1000 |    63.37 ns | 0.473 ns | 0.442 ns |
+|                     GetFSharpMap |           1000 |   107.45 ns | 0.750 ns | 0.702 ns |
+|                GetFSharpXHashMap |           1000 |   121.31 ns | 2.338 ns | 2.187 ns |
+| GetSystemCollectionsImmutableMap |           1000 |    55.16 ns | 0.103 ns | 0.097 ns |
+|         GetFSharpDataAdaptiveMap |           1000 |    66.20 ns | 0.463 ns | 0.433 ns |
+|                       GetHashMap |         100000 |    26.30 ns | 0.011 ns | 0.008 ns |
+|                GetImToolsHashMap |         100000 |   197.11 ns | 0.222 ns | 0.196 ns |
+|                     GetFSharpMap |         100000 |   192.56 ns | 2.011 ns | 1.680 ns |
+|                GetFSharpXHashMap |         100000 |   144.00 ns | 0.673 ns | 0.630 ns |
+| GetSystemCollectionsImmutableMap |         100000 |   141.04 ns | 0.067 ns | 0.062 ns |
+|         GetFSharpDataAdaptiveMap |         100000 |   141.15 ns | 0.867 ns | 0.811 ns |
+|                       GetHashMap |         500000 |    71.60 ns | 0.108 ns | 0.090 ns |
+|                GetImToolsHashMap |         500000 |   502.08 ns | 1.257 ns | 1.114 ns |
+|                     GetFSharpMap |         500000 |   305.92 ns | 3.317 ns | 3.103 ns |
+|                GetFSharpXHashMap |         500000 |   235.47 ns | 1.090 ns | 0.966 ns |
+| GetSystemCollectionsImmutableMap |         500000 |   314.52 ns | 0.540 ns | 0.505 ns |
+|         GetFSharpDataAdaptiveMap |         500000 |   301.50 ns | 1.213 ns | 1.135 ns |
+|                       GetHashMap |         750000 |   100.81 ns | 0.036 ns | 0.032 ns |
+|                GetImToolsHashMap |         750000 |   629.57 ns | 0.300 ns | 0.266 ns |
+|                     GetFSharpMap |         750000 |   391.61 ns | 7.643 ns | 7.149 ns |
+|                GetFSharpXHashMap |         750000 |   356.89 ns | 0.542 ns | 0.507 ns |
+| GetSystemCollectionsImmutableMap |         750000 |   391.42 ns | 0.764 ns | 0.715 ns |
+|         GetFSharpDataAdaptiveMap |         750000 |   354.98 ns | 0.241 ns | 0.225 ns |
+|                       GetHashMap |        1000000 |   113.54 ns | 0.356 ns | 0.333 ns |
+|                GetImToolsHashMap |        1000000 |   692.17 ns | 1.626 ns | 1.521 ns |
+|                     GetFSharpMap |        1000000 |   469.54 ns | 2.890 ns | 2.703 ns |
+|                GetFSharpXHashMap |        1000000 |   349.94 ns | 1.032 ns | 0.965 ns |
+| GetSystemCollectionsImmutableMap |        1000000 |   484.46 ns | 0.480 ns | 0.425 ns |
+|         GetFSharpDataAdaptiveMap |        1000000 |   387.18 ns | 0.320 ns | 0.284 ns |
+|                       GetHashMap |        5000000 |   142.23 ns | 0.050 ns | 0.047 ns |
+|                GetImToolsHashMap |        5000000 | 1,282.78 ns | 0.596 ns | 0.558 ns |
+|                     GetFSharpMap |        5000000 |   851.10 ns | 1.426 ns | 1.334 ns |
+|                GetFSharpXHashMap |        5000000 |   375.16 ns | 0.812 ns | 0.719 ns |
+| GetSystemCollectionsImmutableMap |        5000000 |   850.68 ns | 0.405 ns | 0.359 ns |
+|         GetFSharpDataAdaptiveMap |        5000000 |   608.75 ns | 0.250 ns | 0.233 ns |
+|                       GetHashMap |       10000000 |   158.64 ns | 0.110 ns | 0.097 ns |
+|                GetImToolsHashMap |       10000000 | 1,565.47 ns | 1.311 ns | 1.227 ns |
+|                     GetFSharpMap |       10000000 | 1,041.04 ns | 1.536 ns | 1.436 ns |
+|                GetFSharpXHashMap |       10000000 |   406.87 ns | 0.664 ns | 0.621 ns |
+| GetSystemCollectionsImmutableMap |       10000000 | 1,016.19 ns | 2.372 ns | 2.218 ns |
+|         GetFSharpDataAdaptiveMap |       10000000 |   702.30 ns | 2.080 ns | 1.946 ns |
 ```
 
 ### Add on HashMap

--- a/src/FSharp.HashCollections/FSharp.HashCollections.fsproj
+++ b/src/FSharp.HashCollections/FSharp.HashCollections.fsproj
@@ -8,7 +8,7 @@
     <PackageId>FSharp.HashCollections</PackageId>
     <Title>FSharp.HashCollections</Title>
     <PackageDescription>Immutable hash collections</PackageDescription>
-    <PackageVersion>0.0.1</PackageVersion>
+    <PackageVersion>0.1.0</PackageVersion>
     <Authors>mvkara</Authors>
     <PackageTags>fsharp;collections;hamt;hashmap;hashset;map;set</PackageTags>
     <RepositoryUrl>https://github.com/mvkara/fsharp-hashcollections</RepositoryUrl>

--- a/src/FSharp.HashCollections/HashSet.fs
+++ b/src/FSharp.HashCollections/HashSet.fs
@@ -1,20 +1,22 @@
 module FSharp.HashCollections.HashSet
 
 let contains (k: 'tk) (hashMap: HashSet<'tk, 'teq>) : bool = 
-    HashTrie.tryFind id id k hashMap.HashTrieRoot |> ValueOption.isSome
+    HashTrie.tryFind id id hashMap.EqualityComparer k hashMap.HashTrieRoot |> ValueOption.isSome
 
 let add (k: 'tk) (hashMap: HashSet<'tk, 'teq>) =
-    HashTrie.add id k hashMap.HashTrieRoot |> HashSet
+    HashSet<_, _>(HashTrie.add id hashMap.EqualityComparer k hashMap.HashTrieRoot, hashMap.EqualityComparer)
 
 let remove (k: 'tk) (hashMap: HashSet<'tk, 'teq>) = 
-    HashTrie.remove id k hashMap.HashTrieRoot |> HashSet
+    HashSet<_, _>(HashTrie.remove id hashMap.EqualityComparer k hashMap.HashTrieRoot, hashMap.EqualityComparer)
 
 let count (h: HashSet<_, _>) = HashTrie.count h.HashTrieRoot
 
 let emptyWithComparer<'tk, 'teq when 'teq :> System.Collections.Generic.IEqualityComparer<'tk> and 'teq : (new : unit -> 'teq)> : HashSet<'tk, 'teq> = 
-    HashTrie.emptyWithComparer<'tk, 'teq> |> HashSet
+    let eqTemplate = new 'teq()
+    HashSet<_, _>(HashTrie.empty, eqTemplate)
 
-let empty<'tk when 'tk :> System.IEquatable<'tk> and 'tk : equality> : HashSet<'tk, StandardEqualityTemplate<'tk>> = HashTrie.emptyWithComparer<'tk, StandardEqualityTemplate<'tk>> |> HashSet
+let empty<'tk when 'tk :> System.IEquatable<'tk> and 'tk : equality> : HashSet<'tk> = 
+    HashSet<'tk>(HashTrie.empty, HashIdentity.Structural)
 
 let toSeq (h: HashSet<'tk, _>) : 'tk seq = h.HashTrieRoot |> HashTrie.toSeq
 

--- a/src/FSharp.HashCollections/Types.fs
+++ b/src/FSharp.HashCollections/Types.fs
@@ -1,28 +1,7 @@
 namespace FSharp.HashCollections
 
 open System.Collections.Generic
-open System
 open System.Runtime.CompilerServices
-
-module internal EqualityTemplateLookup = 
-    let inline eqComparer<'tk, 'teq when 'teq :> IEqualityComparer<'tk> and 'teq : (new: unit -> 'teq)> = 
-        new 'teq()
-
-type StandardEqualityTemplate<'tk when 'tk :> IEquatable<'tk> and 'tk : equality> =
-    // This is a struct for the following reasons:
-    // 1. Low cost/no cost allocation meaning we don't need to store this somewhere and can create one each time.
-    // Static field access is MUCH slower.
-    // 2. Calls to struct can be inlined by the JIT and use the "call" instruction under the hood since there's no virtual dispatch.
-    struct
-    end
-    //inherit EqualityTemplate<'tk>()
-    interface IEqualityComparer<'tk> with
-        [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
-        member __.Equals(o1, o2) = o1.Equals(o2)
-        [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
-        member __.GetHashCode(o) = o.GetHashCode()
-
-//type [<IsReadOnly; Struct>] internal HashMapEntry<'tk, 'tv> = { Key: 'tk; Value: 'tv }
 
 type internal HashTrieNode<'tk> =
     | TrieNodeFull of nodes: HashTrieNode<'tk> array
@@ -31,17 +10,23 @@ type internal HashTrieNode<'tk> =
     | EntryNode of entry: 'tk
     | HashCollisionNode of entries: 'tk list
 
-type [<Struct; IsReadOnly>] internal HashTrieRoot<'tk, 'teq> = {
+type [<Struct>] internal HashTrieRoot<'tnode> = {
     CurrentCount: int32
-    RootData: HashTrieNode<'tk>
+    RootData: HashTrieNode<'tnode>
 }
 
 /// Immutable hash map.
-type [<Struct; IsReadOnly>] HashMap<'tk, 'tv, 'teq> = 
-    val internal HashTrieRoot: HashTrieRoot<KeyValuePair<'tk, 'tv>, 'teq>
-    internal new(d) = { HashTrieRoot = d }
+type [<Struct; IsReadOnly>] HashMap<'tk, 'tv, 'teq when 'teq :> IEqualityComparer<'tk>> = 
+    val internal HashTrieRoot: HashTrieRoot<KeyValuePair<'tk, 'tv>>
+    val internal EqualityComparer: 'teq
+    internal new(d, eq) = { HashTrieRoot = d; EqualityComparer = eq }
+
+type HashMap<'tk, 'tv> = HashMap<'tk, 'tv, IEqualityComparer<'tk>>
 
 /// Immutable hash set.
-type [<Struct; IsReadOnly>] HashSet<'tk, 'teq> = 
-    val internal HashTrieRoot: HashTrieRoot<'tk, 'teq>
-    internal new(d) = { HashTrieRoot = d }
+type [<Struct; IsReadOnly>] HashSet<'tk, 'teq when 'teq :> IEqualityComparer<'tk>> = 
+    val internal HashTrieRoot: HashTrieRoot<'tk>
+    val internal EqualityComparer: 'teq
+    internal new(d, eq) = { HashTrieRoot = d; EqualityComparer = eq }
+
+type HashSet<'tk> = HashSet<'tk, IEqualityComparer<'tk>>


### PR DESCRIPTION
The default equality constraints no longer need IEquatable<'tk> allowing usage of this library in more scenarios (e.g. tuple keys for hashMap)

The option is still there to define your own StandardEqualityTemplate<_> using IEquatable<_> for slightly better performance. Performance hit is round 6-13.1% (bigger collections -> smaller collections).

e.g. Using an equality comparer like below given the below Get statistics.

```
type [<Struct>] IntEqualityTemplate = 
    struct end
    interface IEqualityComparer<int> with
        [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
        member __.Equals(x: int, y: int): bool = x = y
        [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
        member __.GetHashCode(obj: int): int = obj
```

```
// * Summary *

BenchmarkDotNet=v0.12.0, OS=arch 
AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.100
  [Host]     : .NET Core 3.1.0 (CoreCLR 4.700.19.56402, CoreFX 4.700.19.56404), X64 RyuJIT DEBUG
  DefaultJob : .NET Core 3.1.0 (CoreCLR 4.700.19.56402, CoreFX 4.700.19.56404), X64 RyuJIT


|                           Method | CollectionSize |         Mean |     Error |     StdDev |
|--------------------------------- |--------------- |-------------:|----------:|-----------:|
|                       GetHashMap |             10 |     9.926 ns | 0.0050 ns |  0.0045 ns |
|                GetImToolsHashMap |             10 |    28.958 ns | 0.3388 ns |  0.3169 ns |
|                     GetFSharpMap |             10 |    40.643 ns | 0.7644 ns |  0.8180 ns |
|                GetFSharpXHashMap |             10 |   101.132 ns | 1.4956 ns |  1.3990 ns |
| GetSystemCollectionsImmutableMap |             10 |    24.802 ns | 0.0192 ns |  0.0180 ns |
|         GetFSharpDataAdaptiveMap |             10 |    21.508 ns | 0.0242 ns |  0.0226 ns |
|                       GetHashMap |            100 |    12.975 ns | 0.0122 ns |  0.0114 ns |
|                GetImToolsHashMap |            100 |    42.124 ns | 0.1862 ns |  0.1650 ns |
|                     GetFSharpMap |            100 |    68.672 ns | 1.3138 ns |  1.4058 ns |
|                GetFSharpXHashMap |            100 |   108.293 ns | 1.7887 ns |  1.6732 ns |
| GetSystemCollectionsImmutableMap |            100 |    37.061 ns | 0.1476 ns |  0.1380 ns |
|         GetFSharpDataAdaptiveMap |            100 |    43.039 ns | 0.2861 ns |  0.2676 ns |
|                       GetHashMap |           1000 |    10.848 ns | 0.0630 ns |  0.0558 ns |
|                GetImToolsHashMap |           1000 |    64.617 ns | 0.7955 ns |  0.7052 ns |
|                     GetFSharpMap |           1000 |   103.911 ns | 1.5896 ns |  1.4869 ns |
|                GetFSharpXHashMap |           1000 |   114.621 ns | 1.5813 ns |  1.4791 ns |
| GetSystemCollectionsImmutableMap |           1000 |    53.906 ns | 0.1334 ns |  0.1248 ns |
|         GetFSharpDataAdaptiveMap |           1000 |    64.895 ns | 0.0290 ns |  0.0257 ns |
|                       GetHashMap |         100000 |    21.664 ns | 0.0152 ns |  0.0142 ns |
|                GetImToolsHashMap |         100000 |   197.040 ns | 0.2883 ns |  0.2696 ns |
|                     GetFSharpMap |         100000 |   199.662 ns | 1.8501 ns |  1.7306 ns |
|                GetFSharpXHashMap |         100000 |   142.963 ns | 0.9620 ns |  0.8999 ns |
| GetSystemCollectionsImmutableMap |         100000 |   140.797 ns | 0.1237 ns |  0.1097 ns |
|         GetFSharpDataAdaptiveMap |         100000 |   140.721 ns | 0.0986 ns |  0.0874 ns |
|                       GetHashMap |         500000 |    68.142 ns | 0.2851 ns |  0.2527 ns |
|                GetImToolsHashMap |         500000 |   504.818 ns | 1.2397 ns |  1.0989 ns |
|                     GetFSharpMap |         500000 |   309.818 ns | 1.5171 ns |  1.4191 ns |
|                GetFSharpXHashMap |         500000 |   235.187 ns | 0.6484 ns |  0.6065 ns |
| GetSystemCollectionsImmutableMap |         500000 |   314.714 ns | 2.7851 ns |  2.6052 ns |
|         GetFSharpDataAdaptiveMap |         500000 |   304.446 ns | 0.1927 ns |  0.1708 ns |
|                       GetHashMap |         750000 |    95.958 ns | 0.0394 ns |  0.0329 ns |
|                GetImToolsHashMap |         750000 |   633.324 ns | 0.7520 ns |  0.7034 ns |
|                     GetFSharpMap |         750000 |   402.166 ns | 6.9027 ns |  6.4567 ns |
|                GetFSharpXHashMap |         750000 |   354.521 ns | 0.5895 ns |  0.5226 ns |
| GetSystemCollectionsImmutableMap |         750000 |   398.067 ns | 0.5295 ns |  0.4694 ns |
|         GetFSharpDataAdaptiveMap |         750000 |   347.982 ns | 0.1823 ns |  0.1616 ns |
|                       GetHashMap |        1000000 |   105.326 ns | 0.0559 ns |  0.0523 ns |
|                GetImToolsHashMap |        1000000 |   691.492 ns | 0.4034 ns |  0.3576 ns |
|                     GetFSharpMap |        1000000 |   455.620 ns | 8.9881 ns | 11.3670 ns |
|                GetFSharpXHashMap |        1000000 |   347.568 ns | 1.2698 ns |  1.1878 ns |
| GetSystemCollectionsImmutableMap |        1000000 |   483.456 ns | 0.6303 ns |  0.5896 ns |
|         GetFSharpDataAdaptiveMap |        1000000 |   385.804 ns | 0.2885 ns |  0.2409 ns |
|                       GetHashMap |        5000000 |   134.836 ns | 0.1230 ns |  0.1090 ns |
|                GetImToolsHashMap |        5000000 | 1,264.685 ns | 2.9860 ns |  2.7931 ns |
|                     GetFSharpMap |        5000000 |   853.400 ns | 2.6057 ns |  2.4374 ns |
|                GetFSharpXHashMap |        5000000 |   382.427 ns | 0.8251 ns |  0.7314 ns |
| GetSystemCollectionsImmutableMap |        5000000 |   855.713 ns | 0.4535 ns |  0.4242 ns |
|         GetFSharpDataAdaptiveMap |        5000000 |   609.845 ns | 0.4041 ns |  0.3583 ns |
|                       GetHashMap |       10000000 |   152.434 ns | 0.0767 ns |  0.0718 ns |
|                GetImToolsHashMap |       10000000 | 1,605.469 ns | 1.2254 ns |  1.1463 ns |
|                     GetFSharpMap |       10000000 | 1,046.320 ns | 2.3946 ns |  2.2399 ns |
|                GetFSharpXHashMap |       10000000 |   390.366 ns | 1.5520 ns |  1.4517 ns |
| GetSystemCollectionsImmutableMap |       10000000 | 1,019.647 ns | 1.5931 ns |  1.4902 ns |
|         GetFSharpDataAdaptiveMap |       10000000 |   707.831 ns | 0.3499 ns |  0.3102 ns |
```