### PR TITLE
resolves #17 - toString() on both collections, read only dict for map…

### DIFF
--- a/src/FSharp.HashCollections/FSharp.HashCollections.fsproj
+++ b/src/FSharp.HashCollections/FSharp.HashCollections.fsproj
@@ -8,7 +8,7 @@
     <PackageId>FSharp.HashCollections</PackageId>
     <Title>FSharp.HashCollections</Title>
     <PackageDescription>Immutable hash collections</PackageDescription>
-    <PackageVersion>0.2.0</PackageVersion>
+    <PackageVersion>0.3.0</PackageVersion>
     <Authors>mvkara</Authors>
     <PackageTags>fsharp;collections;hamt;hashmap;hashset;map;set</PackageTags>
     <RepositoryUrl>https://github.com/mvkara/fsharp-hashcollections</RepositoryUrl>

--- a/src/FSharp.HashCollections/HamtImpl.fs
+++ b/src/FSharp.HashCollections/HamtImpl.fs
@@ -346,5 +346,5 @@ module internal HashTrie =
     let empty< 'tk, 'eq when 'eq : (new : unit -> 'eq)> : HashTrieRoot< ^tk> =
         { CurrentCount = 0; RootData = TrieNode(CompressedArray.empty) }
 
-    let inline equals (eqTemplate: 'teq when 'teq :> IEqualityComparer<_>) equalKeyExtractor (h1: HashTrieRoot<'n>) (h2: HashTrieRoot<'n>) =
-        h1.CurrentCount = h2.CurrentCount && Seq.forall (fun (x, y) -> eqTemplate.Equals(equalKeyExtractor x, equalKeyExtractor y)) (Seq.zip (toSeq h1) (toSeq h2))
+    let inline equals (eqTemplate: 'teq when 'teq :> IEqualityComparer<_>) equalKeyExtractor ([<InlineIfLambda>] extraCheck) (h1: HashTrieRoot<'n>) (h2: HashTrieRoot<'n>) =
+        h1.CurrentCount = h2.CurrentCount && Seq.forall (fun (x, y) -> eqTemplate.Equals(equalKeyExtractor x, equalKeyExtractor y) && extraCheck x y) (Seq.zip (toSeq h1) (toSeq h2))

--- a/src/FSharp.HashCollections/InternalTypes.fs
+++ b/src/FSharp.HashCollections/InternalTypes.fs
@@ -15,3 +15,14 @@ type [<Struct>] internal HashTrieRoot<'tnode> = {
     CurrentCount: int32
     RootData: HashTrieNode<'tnode>
 }
+
+module internal HelperFunctions =
+
+    // Taken from https://github.com/fsharp/fsharp/blob/master/src/fsharp/FSharp.Core/prim-types.fs to be consistent with F# Map handling (MIT License - https://github.com/fsharp/fsharp/blob/master/License.txt)
+    let inline anyToString nullStr x =
+        match box x with
+        | null -> nullStr
+        | :? System.IFormattable as f -> f.ToString(null,System.Globalization.CultureInfo.InvariantCulture)
+        | obj ->  obj.ToString()
+
+    let anyToStringShowingNull x = anyToString "null" x

--- a/test/FSharp.HashCollections.Unit/HashMapTest.fs
+++ b/test/FSharp.HashCollections.Unit/HashMapTest.fs
@@ -109,7 +109,7 @@ let assertEqualsTheSame actions =
 
 let [<Tests>] tests =
     testList
-        "Hash Trie Property Tests"
+        "Hash Map Property Tests"
         [
           testCase
             "Adding 3 k-v pairs"
@@ -142,6 +142,35 @@ let [<Tests>] tests =
           testCase
             "Empty Map returns IsEmpty"
             (fun () -> Expect.isTrue (HashMap.isEmpty (HashMap.empty |> HashMap.add 1 1 |> HashMap.remove 1)) "HashSet not empty")
+
+          testCase
+            "Not equal map by values returns not equal"
+            (fun () -> Expect.notEqual (HashMap.empty |> HashMap.add 1 1 |> HashMap.add 2 1) (HashMap.empty |> HashMap.add 1 2 |> HashMap.add 2 2) "Equal Hash maps when shouldn't be.")
+
+          testCase
+            "Equal map by values returns equal"
+            (fun () -> Expect.equal (HashMap.empty |> HashMap.add 1 1 |> HashMap.add 2 2) (HashMap.empty |> HashMap.add 1 1 |> HashMap.add 2 2) "Not Equal Hash maps when should be.")
+
+          testCase
+            "Nested map by values returns equal"
+            (fun () ->
+              let buildHashMap() = hashMap [ (1, hashMap [ (2, 3) ]); (4, hashMap [ (5, 6) ]) ]
+              Expect.equal (buildHashMap()) (buildHashMap()) "Not equal when should be")
+
+          testCase
+            "Nested map not equal by values returns not equal"
+            (fun () ->
+              let buildHashMap v = hashMap [ (1, hashMap [ (2, v) ]); (4, hashMap [ (5, 6) ]) ]
+              Expect.notEqual (buildHashMap 5) (buildHashMap 7) "Not equal when should be")
+
+          testCase
+            "ToString output is expected"
+            (fun () ->
+              let testHashMap = hashMap [ (1, hashMap [ (3, 4)]); (5, hashMap [(6, 7)] ) ]
+              Expect.equal
+                (testHashMap.ToString())
+                "hashMap [(1, hashMap [(3, 4)]); (5, hashMap [(6, 7)])]"
+                "toString not valid" )
 
           generateLargeSizeMapOfSeqTest()
 

--- a/test/FSharp.HashCollections.Unit/HashSetTest.fs
+++ b/test/FSharp.HashCollections.Unit/HashSetTest.fs
@@ -175,6 +175,35 @@ let [<Tests>] tests =
             "Empty Set returns IsEmpty"
             (fun () -> Expect.isTrue (HashSet.isEmpty (HashSet.empty |> HashSet.add 1 |> HashSet.remove 1)) "HashSet not empty")
 
+          testCase
+            "Not equal set by values returns not equal"
+            (fun () -> Expect.notEqual (HashSet.empty |> HashSet.add 1 |> HashSet.add 2) (HashSet.empty |> HashSet.add 3 |> HashSet.add 2) "Equal Hash Sets when shouldn't be.")
+
+          testCase
+            "Equal set by values returns equal"
+            (fun () -> Expect.equal (HashSet.empty |> HashSet.add 1 |> HashSet.add 2) (HashSet.empty |> HashSet.add 1 |> HashSet.add 2) "Not equal hash sets when should be.")
+
+          testCase
+            "Nested set by values returns equal"
+            (fun () ->
+              let buildHashSet() = hashSet [ (1, hashSet [ (2, 3) ]); (2, hashSet [ (5, 6) ]) ]
+              Expect.equal (buildHashSet()) (buildHashSet()) "Not equal when should be")
+
+          testCase
+            "Nested set by different nested value returns not equal"
+            (fun () ->
+              let buildHashSet v = hashSet [ (1, hashSet [ (2, v) ]); (2, hashSet [ (5, 6) ]) ]
+              Expect.notEqual (buildHashSet 5) (buildHashSet 7) "equal when should not be")
+
+          testCase
+            "ToString output is expected"
+            (fun () ->
+              let testHashSet = hashSet [ hashSet [1; 2]; hashSet [3; 4] ]
+              Expect.equal
+                (testHashSet.ToString())
+                "hashSet [hashSet [1; 2]; hashSet [3; 4]]"
+                "toString not valid" )
+
           generateLargeSizeMapTest()
 
           generateLargeSizeMapOfSeqTest()


### PR DESCRIPTION
- [X] F# ToString like behaviour on collections
- [X] Equality fix on hash map
- [X] IReadOnlyDictionary interface on HashMap