### PR TITLE
Move to new hash structure for even more performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/obj
 .ionide
 .vscode
+.fake

--- a/src/FSharp.HashCollections/CompressedArray.fs
+++ b/src/FSharp.HashCollections/CompressedArray.fs
@@ -4,7 +4,7 @@ open System.Runtime.Intrinsics
 open System
 open System.Runtime.CompilerServices
 
-type BitMaskType = uint64
+type BitMaskType = uint32
 
 /// A fixed length array like structure. Only allocates as many entries as required to store elements with a maximum of sizeof(BitMap) elements.
 type [<Struct>] internal CompressedArray<'t> = { BitMap: BitMaskType; Content: 't array }
@@ -38,8 +38,8 @@ module internal CompressedArray =
 
     let [<Literal>] MaxSize = 32
     let [<Literal>] AllNodesSetBitMap = BitMaskType.MaxValue
-    let [<Literal>] Zero : BitMaskType = 0UL
-    let [<Literal>] One : BitMaskType = 1UL
+    let [<Literal>] Zero : BitMaskType = 0u
+    let [<Literal>] One : BitMaskType = 1u
     let [<Literal>] LeastSigBitSet = One
 
     /// Has a software fallback if not supported built inside with an IF statement.

--- a/src/FSharp.HashCollections/FSharp.HashCollections.fsproj
+++ b/src/FSharp.HashCollections/FSharp.HashCollections.fsproj
@@ -8,7 +8,7 @@
     <PackageId>FSharp.HashCollections</PackageId>
     <Title>FSharp.HashCollections</Title>
     <PackageDescription>Immutable hash collections</PackageDescription>
-    <PackageVersion>0.3.1</PackageVersion>
+    <PackageVersion>0.3.2</PackageVersion>
     <Authors>mvkara</Authors>
     <PackageTags>fsharp;collections;hamt;hashmap;hashset;map;set</PackageTags>
     <RepositoryUrl>https://github.com/mvkara/fsharp-hashcollections</RepositoryUrl>

--- a/src/FSharp.HashCollections/HamtImpl.fs
+++ b/src/FSharp.HashCollections/HamtImpl.fs
@@ -15,7 +15,8 @@ module internal HashTrie =
     let inline getIndex keyHash shift = getIndexNoShift (keyHash >>> shift)
 
     let inline tryFind
-        (keyExtractor: 'tknode -> 'tk) (valueExtractor: 'tknode -> 'tv)
+        (keyExtractor: 'tknode -> 'tk)
+        (valueExtractor: 'tknode -> 'tv)
         (eqTemplate: 'teq when 'teq :> IEqualityComparer<'tk>)
         (k: 'tk)
         (hashMap: HashTrieRoot<'tknode>) : 'tv voption =
@@ -33,39 +34,31 @@ module internal HashTrie =
                 | [] -> ValueNone
             findInList l
 
-        let rec getRec node remainderHash =
+        let rec getRec
+            node remainderHash =
             match node with
-            | TrieNodeFull(nodes) ->
-                let index = getIndexNoShift remainderHash
-                getRec nodes.[index] (remainderHash >>> PartitionSize)
-            | TrieNode(nodes) ->
+            | TrieNode(nodes, values) ->
                 let bitPos = CompressedArray.getBitMapForIndex (getIndexNoShift remainderHash)
                 if CompressedArray.boundsCheckIfSetForBitMapIndex nodes.BitMap bitPos // This checks if the bit was set in the first place.
                 then
                     getRec
                         (nodes.Content.[CompressedArray.getCompressedIndexForIndexBitmap nodes.BitMap bitPos])
                         (remainderHash >>> PartitionSize)
+                elif CompressedArray.boundsCheckIfSetForBitMapIndex values.BitMap bitPos 
+                then
+                    let node = values.Content.[CompressedArray.getCompressedIndexForIndexBitmap values.BitMap bitPos]
+                    let nodeKey = keyExtractor node
+                    if eqTemplate.Equals(nodeKey, k)
+                    then valueExtractor node |> ValueSome
+                    else ValueNone
                 else
                     ValueNone
-            | TrieNodeOne(nodeIndex, node) ->
-                let index = getIndexNoShift remainderHash
-                if nodeIndex = index
-                then getRec node (remainderHash >>> PartitionSize)
-                else ValueNone
-            | EntryNode entry ->
-                let extractedKey = keyExtractor entry
-                if eqTemplate.Equals(extractedKey, k) then ValueSome (valueExtractor entry) else ValueNone
             | HashCollisionNode entries -> tryFindValueInList entries
 
         getRec hashMap.RootData keyHash
 
-    let inline createTrieNode (nodes: CompressedArray<_>) =
-        match nodes.Content.Length with
-        | CompressedArray.MaxSize -> TrieNodeFull(nodes.Content)
-        | _ -> TrieNode(nodes)
-
-    let addNodesToResolveConflict existingEntry newEntry existingEntryHash currentKeyHash shift =
-        let rec createRequiredDepthNodes shift =
+    let addNodesToResolveConflict oldNodeMap oldValuesMap existingEntry newEntry existingEntryHash currentKeyHash shift =
+        let rec createRequiredDepthNodes (first: bool) shift =
             let existingEntryIndex = getIndex existingEntryHash shift
             let currentEntryIndex = getIndex currentKeyHash shift
             if shift >= MaxShiftValue
@@ -75,13 +68,15 @@ module internal HashTrie =
                 then
                     let ca =
                         CompressedArray.ofTwoElements
-                            existingEntryIndex (EntryNode existingEntry)
-                            currentEntryIndex (EntryNode newEntry)
-                    TrieNode(ca)
+                            existingEntryIndex existingEntry
+                            currentEntryIndex newEntry
+                    TrieNode(CompressedArray.empty, ca)
                 else
-                    let subNode = createRequiredDepthNodes (shift + PartitionSize)
-                    TrieNodeOne(existingEntryIndex, subNode)
-        createRequiredDepthNodes shift
+                    let subNode = createRequiredDepthNodes false (shift + PartitionSize)
+                    if first
+                    then TrieNode(CompressedArray.set existingEntryIndex subNode oldNodeMap, CompressedArray.unset currentEntryIndex oldValuesMap) // Not sure about empty here.
+                    else TrieNode(CompressedArray.ofSingleElement existingEntryIndex subNode, CompressedArray.empty) // Not sure about empty here.
+        createRequiredDepthNodes true shift
 
     let inline add
         (keyExtractor: 'tknode -> 'tk)
@@ -97,48 +92,29 @@ module internal HashTrie =
 
         let rec addRec node shift =
             match node with
-            | TrieNode(nodes) ->
+            | TrieNode(nodes, values) ->
                 let index = getIndex keyHash shift
                 let bit = CompressedArray.getBitMapForIndex index
-                if (bit &&& nodes.BitMap) <> CompressedArray.Zero then
+                if (bit &&& nodes.BitMap) <> CompressedArray.Zero then // Case where node is already present, just recursively update it and replace.
                     let compressedIndex = CompressedArray.getCompressedIndexForIndexBitmap nodes.BitMap bit
                     let nodeAtPos = nodes.Content.[compressedIndex]
+                    // Part that isn't tail recursive.
                     let struct (newPosNode, isAdded) = addRec nodeAtPos (shift + PartitionSize)
-                    struct (TrieNode (nodes |> CompressedArray.replaceNoCheck compressedIndex newPosNode), isAdded)
+                    struct (TrieNode (nodes |> CompressedArray.replaceNoCheck compressedIndex newPosNode, values), isAdded)
+                elif (bit &&& values.BitMap) <> CompressedArray.Zero then // Where there is a value with that current one.
+                    let compressedIndex = CompressedArray.getCompressedIndexForIndexBitmap values.BitMap bit
+                    let valueAtPos = values.Content.[compressedIndex]
+                    let extractedKey = keyExtractor valueAtPos
+                    if equals extractedKey key
+                    then struct (TrieNode(nodes, CompressedArray.replaceNoCheck compressedIndex knode values), false) // Replace existing value
+                    else struct (addNodesToResolveConflict nodes values valueAtPos knode (hash extractedKey) keyHash shift, true) // Move value to node list and create nodes as appropriate.
                 else
-                    if nodes.Content.Length = CompressedArray.MaxSize - 1
-                    then
-                        let uncompressedArray = ArrayHelpers.copyArrayInsertInMiddle index (EntryNode knode) nodes.Content
-                        struct (TrieNodeFull uncompressedArray, true)
-                    else
-                        // Add new entry
-                        let newBitMap = nodes.BitMap ||| bit
-                        let compressedIndex = CompressedArray.getCompressedIndexForIndexBitmap nodes.BitMap bit
-                        let newContent = ArrayHelpers.copyArrayInsertInMiddle compressedIndex (EntryNode knode) nodes.Content
-                        let newCa =  { BitMap = newBitMap; Content = newContent }
-                        struct (TrieNode newCa, true)
-            | TrieNodeOne(nodeIndex, nodeAtPos) ->
-                let index = getIndex keyHash shift
-                if nodeIndex.Equals(index)
-                then
-                    let struct (newPosNode, isAdded) = addRec nodeAtPos (shift + PartitionSize)
-                    struct (TrieNodeOne(index, newPosNode), isAdded)
-                else
-                    let entryNode = EntryNode(knode)
-                    let ca = CompressedArray.ofTwoElements nodeIndex nodeAtPos index entryNode
-                    struct (TrieNode(ca), true)
-            | TrieNodeFull(nodes) ->
-                let index = getIndex keyHash shift
-                let nodeAtPos = nodes.[index]
-                let struct (newPosNode, isAdded) = addRec nodeAtPos (shift + PartitionSize)
-                let newNodes = ArrayHelpers.copyArray nodes
-                newNodes.[index] <- newPosNode
-                struct (TrieNodeFull newNodes, isAdded)
-            | EntryNode entry ->
-                let extractedKey = keyExtractor entry
-                if equals extractedKey key
-                then struct (EntryNode knode, false) // Replacement
-                else struct (addNodesToResolveConflict entry knode (hash extractedKey) keyHash shift, true) // Create one or more levels required.
+                    // Add new entry
+                    let newBitMap = values.BitMap ||| bit
+                    let compressedIndex = CompressedArray.getCompressedIndexForIndexBitmap values.BitMap bit
+                    let newContent = ArrayHelpers.copyArrayInsertInMiddle compressedIndex knode values.Content
+                    let newCa = { BitMap = newBitMap; Content = newContent }
+                    struct (TrieNode(nodes, newCa), true)
             | HashCollisionNode entries ->
                 if shift < MaxShiftValue then failwithf "Not expected to exist"
                 let rec replaceElementIfExists previouslySeen tailList =
@@ -163,100 +139,81 @@ module internal HashTrie =
     /// Takes in an empty root and creates a populated structure using the sequence given.
     /// NOTE: This is not thread safe andd violates immutability when passed in - safe to use for new instances.
     let inline ofSeq
-        (keyExtractor: 'tknode -> 'tk)
+        ([<InlineIfLambda>] keyExtractor: 'tknode -> 'tk)
         (eqTemplate: 'teq when 'teq :> IEqualityComparer<'tk>)
-        (knode: #seq<'tknode>)
+        (nodeList: #seq<'tknode>)
         (hashMap: HashTrieRoot<'tknode>) : HashTrieRoot<'tknode> =
+
         let inline equals x y = eqTemplate.Equals(x, y)
         let inline hash o = eqTemplate.GetHashCode(o)
 
-        let folder hashMap knode =
-
+        let addInner (knode: 'tknode) (hashTrieNode: HashTrieNode<'tknode>) =
             let key = keyExtractor knode
             let keyHash = hash key
 
-            // Because we are using a high branching factor this almost always hits. This is the slow method which causes issues with ofSeq methods.
-            let rec trieNode nodes shift =
-                let index = getIndex keyHash shift
-                let bit = CompressedArray.getBitMapForIndex index
-                if (bit &&& nodes.BitMap) <> CompressedArray.Zero then
-                    let compressedIndex = CompressedArray.getCompressedIndexForIndexBitmap nodes.BitMap bit
-                    let nodeAtPos = nodes.Content.[compressedIndex]
-                    let struct (newPosNode, isAdded) = addRec nodeAtPos (shift + PartitionSize)
-                    let newNodesArray = nodes.Content.[compressedIndex] <- newPosNode; nodes
-                    struct (TrieNode newNodesArray, isAdded)
-                else
-                    if nodes.Content.Length = CompressedArray.MaxSize - 1
-                    then
-                        let uncompressedArray = ArrayHelpers.copyArrayInsertInMiddle index (EntryNode knode) nodes.Content
-                        struct (TrieNodeFull uncompressedArray, true)
-                    else
-                        // Add new entry
-                        let newBitMap = nodes.BitMap ||| bit
-                        let compressedIndex = CompressedArray.getCompressedIndexForIndexBitmap nodes.BitMap bit
-                        let newContent = ArrayHelpers.copyArrayInsertInMiddle compressedIndex (EntryNode knode) nodes.Content
-                        let newCa =  { BitMap = newBitMap; Content = newContent }
-                        struct (TrieNode newCa, true)
-
-            and trieNodeFull node (nodes: _ array) shift =
-                let index = getIndex keyHash shift
-                let nodeAtPos = nodes.[index] // This always returns something at this stage, never null.
-                let struct (newPosNode, isAdded) = addRec nodeAtPos (shift + PartitionSize)
-                nodes.[index] <- newPosNode
-                struct (node, isAdded)
-
-            and entryNode entry shift =
-                let extractedKey = keyExtractor entry
-                if equals extractedKey key
-                then struct (EntryNode knode, false) // Replacement
-                else struct (addNodesToResolveConflict entry knode (hash extractedKey) keyHash shift, true)
-
-            and trieNodeOne nodeIndex nodeAtPos shift =
-                let index = getIndex keyHash shift
-                if nodeIndex.Equals(index)
-                then
-                    let struct (newPosNode, isAdded) = addRec nodeAtPos (shift + PartitionSize)
-                    struct (TrieNodeOne(index, newPosNode), isAdded)
-                else
-                    let entryNode = EntryNode(knode)
-                    let ca = CompressedArray.ofTwoElements nodeIndex nodeAtPos index entryNode
-                    struct (TrieNode(ca), true)
-
-            and hashCollisionNode entries shift =
-                if shift < MaxShiftValue then failwithf "Not expected to exist"
-                let rec replaceElementIfExists previouslySeen tailList =
-                    match tailList with
-                    | entryNode :: tail ->
-                        let extractedKey = keyExtractor entryNode
-                        if equals extractedKey key
-                        then (List.append (knode :: previouslySeen) tail, true)
-                        else replaceElementIfExists (entryNode :: previouslySeen) tail
-                    | [] -> ([], false)
-
-                let (newList, replaced) = replaceElementIfExists [] entries
-                if replaced
-                then struct (HashCollisionNode(newList), false)
-                else struct (HashCollisionNode(knode :: entries), true)
-
-            and addRec node shift =
+            let rec addRec node shift =
                 match node with
-                | TrieNode(nodes) -> trieNode nodes shift
-                | TrieNodeOne(nodeIndex, nodeAtPos) -> trieNodeOne nodeIndex nodeAtPos shift
-                | TrieNodeFull(nodes) -> trieNodeFull node nodes shift
-                | EntryNode entry -> entryNode entry shift
-                | HashCollisionNode entries -> hashCollisionNode entries shift
+                | TrieNode(nodes, values) ->
+                    let index = getIndex keyHash shift
+                    let bit = CompressedArray.getBitMapForIndex index
+                    if (bit &&& nodes.BitMap) <> CompressedArray.Zero then // Case where node is already present, just recursively update it and replace.
+                        let compressedIndex = CompressedArray.getCompressedIndexForIndexBitmap nodes.BitMap bit
+                        let nodeAtPos = nodes.Content.[compressedIndex]
+                        let struct (newPosNode, isAdded) = addRec nodeAtPos (shift + PartitionSize)
+                        nodes.Content.[compressedIndex] <- newPosNode
+                        struct (node, isAdded)
+                    elif (bit &&& values.BitMap) <> CompressedArray.Zero then // Where there is a value with that current one.
+                        let compressedIndex = CompressedArray.getCompressedIndexForIndexBitmap values.BitMap bit
+                        let valueAtPos = values.Content.[compressedIndex]
+                        let extractedKey = keyExtractor valueAtPos
+                        if equals extractedKey key
+                        then 
+                            values.Content.[compressedIndex] <- knode
+                            struct (node, false) // Replace existing value
+                        else struct (addNodesToResolveConflict nodes values valueAtPos knode (hash extractedKey) keyHash shift, true) // Move value to node list and create nodes as appropriate.
+                    else
+                        // Add new entry, can't do an in-place update here as array must grow.
+                        let newBitMap = values.BitMap ||| bit
+                        let compressedIndex = CompressedArray.getCompressedIndexForIndexBitmap values.BitMap bit
+                        let newContent = ArrayHelpers.copyArrayInsertInMiddle compressedIndex knode values.Content
+                        let newCa = { BitMap = newBitMap; Content = newContent }
+                        struct (TrieNode(nodes, newCa), true)
+                | HashCollisionNode entries ->
+                    if shift < MaxShiftValue then failwithf "Not expected to exist"
+                    let rec replaceElementIfExists previouslySeen tailList =
+                        match tailList with
+                        | entryNode :: tail ->
+                            let extractedKey = keyExtractor entryNode
+                            if equals extractedKey key
+                            then (List.append (knode :: previouslySeen) tail, true)
+                            else replaceElementIfExists (entryNode :: previouslySeen) tail
+                        | [] -> ([], false)
 
-            let struct (newRootData, isAdded) = addRec hashMap.RootData 0
+                    let (newList, replaced) = replaceElementIfExists [] entries
+                    if replaced
+                    then struct (HashCollisionNode(newList), false)
+                    else struct (HashCollisionNode(knode :: entries), true)
+            addRec hashTrieNode 0
 
-            { CurrentCount = if isAdded then hashMap.CurrentCount + 1 else hashMap.CurrentCount
-              RootData = newRootData }
+        let mutable count = hashMap.CurrentCount
+        let mutable rootData = hashMap.RootData
+        
+        for i in nodeList do
+            let struct (newRootData, isAdded) = addInner i rootData
+            if isAdded then count <- count + 1
+            rootData <- newRootData
 
-        let mutable state = hashMap
-        for itemToAdd in knode do state <- folder state itemToAdd
-        state
+        { CurrentCount = count; RootData = rootData }
+
+    [<Struct>] 
+    type internal SubNodeChange<'t> = 
+        | RemoveChildNode
+        | RemoveChildNodeAndPreserveSingleValue of childValueToPromote: 't
+        | NewChildNode of trieNode: HashTrieNode<'t>
+        | NoChange
 
     let inline remove
-        keyExtractor
+        ([<InlineIfLambda>] keyExtractor)
         (eqTemplate: 'teq when 'teq :> IEqualityComparer<'tk>)
         (k: 'tk)
         (hashMap: HashTrieRoot< 'tknode>) =
@@ -265,77 +222,77 @@ module internal HashTrie =
         let inline hash (o: 'tk) = eqTemplate.GetHashCode(o)
 
         let keyHash = hash k
-        let rec traverseNodes node nodes shift =
+        let rec traverseNodes first nodes values shift =
+            
             let index = getIndex keyHash shift
             match nodes |> CompressedArray.get index with
+            | ValueNone ->
+                match values |> CompressedArray.get index with
+                | ValueSome(entry) -> 
+                    if equals (keyExtractor entry) k
+                    then 
+                        let newValues = CompressedArray.unset index values
+                        match CompressedArray.count nodes, CompressedArray.count newValues with
+                        | (0, 1) when not first -> struct (RemoveChildNodeAndPreserveSingleValue newValues.Content.[0], true)
+                        | (_, _) -> struct (NewChildNode (TrieNode(nodes, values |> CompressedArray.unset index)), true)
+                    else struct (NoChange, false)
+                | ValueNone -> struct (NoChange, false)
             | ValueSome(subNode) ->
-                let struct (newSubNodeList, didWeRemove) =
+                let struct (nodeValueList, newValuesList, didWeRemove) =
                     match subNode with
-                    | TrieNode subNodes ->
-                        let (struct (childNodeOpt, didWeRemove)) = traverseNodes subNode subNodes (shift + PartitionSize)
-                        match childNodeOpt with
-                        | ValueSome(childNode) -> struct (nodes |> CompressedArray.set index childNode, didWeRemove)
-                        | ValueNone -> struct (nodes |> CompressedArray.unset index, didWeRemove)
-                    | TrieNodeFull(subNodes) ->
-                        let (struct (childNodeOpt, didWeRemove)) = traverseNodes subNode (CompressedArray.ofArray subNodes) (shift + PartitionSize)
-                        match childNodeOpt with
-                        | ValueSome(childNode) -> struct (nodes |> CompressedArray.set index childNode, didWeRemove)
-                        | ValueNone -> struct (nodes |> CompressedArray.unset index, didWeRemove)
-                    | EntryNode entry ->
-                        if equals (keyExtractor entry) k
-                        then struct (nodes |> CompressedArray.unset index, true)
-                        else struct (nodes, false) // Same hash but different key, don't remove.
+                    | TrieNode(subNodes, subValues) ->
+                        let subIndex = getIndex keyHash (shift + PartitionSize)
+                        let bit = CompressedArray.getBitMapForIndex subIndex
+                        if ((bit &&& subNodes.BitMap) <> CompressedArray.Zero) || ((bit &&& subValues.BitMap <> CompressedArray.Zero))
+                        then // Case where node is already present, just recursively update it and replace.
+                            let (struct (childNodeOpt, didWeRemove)) = traverseNodes false subNodes subValues (shift + PartitionSize)
+                            match childNodeOpt with
+                            | NewChildNode(childNode) -> struct (nodes |> CompressedArray.set index childNode, values, didWeRemove)
+                            | RemoveChildNode -> struct (nodes |> CompressedArray.unset index, values, didWeRemove)
+                            | RemoveChildNodeAndPreserveSingleValue(promotedNode) ->
+                                struct (nodes |> CompressedArray.unset index, values |> CompressedArray.set index promotedNode, didWeRemove)
+                            | NoChange -> struct (nodes, values, didWeRemove)
+                        else struct (nodes, values, false)
                     | HashCollisionNode collisions ->
                         // TODO: This could be further optimised but hash collisions should be unlikely.
                         let newList = collisions |> List.filter (fun x -> equals (keyExtractor x) k |> not)
                         let didWeRemove = collisions |> List.exists (fun x -> equals (keyExtractor x) k)
                         match newList with
-                        | [ entry ] -> struct (nodes |> CompressedArray.set index (EntryNode entry), didWeRemove) // Project parent node to hash collision and unset where this node was.
-                        | _ :: _ -> struct (nodes |> CompressedArray.set index (HashCollisionNode(newList)), didWeRemove)
-                        | [] -> failwithf "This should never happen; hash collision nodes should always have more than one entry"
-                    | TrieNodeOne(nodeIndex, node) ->
-                        let nodeAsCArray = CompressedArray.ofSingleElement nodeIndex node
-                        let (struct (childNodeOpt, didWeRemove)) = traverseNodes node nodeAsCArray (shift + PartitionSize)
-                        match childNodeOpt with
-                        | ValueSome(childNode) -> struct (nodes |> CompressedArray.set index childNode, didWeRemove)
-                        | ValueNone -> struct (CompressedArray.empty, didWeRemove)
-                if newSubNodeList |> CompressedArray.count = 0
-                then struct (ValueNone, didWeRemove)
-                else struct (ValueSome (createTrieNode (newSubNodeList)), didWeRemove)
-            | ValueNone -> struct (ValueSome node, false)
-
-        let rootIndex = getIndex keyHash 0
+                        | [ entry ] -> struct (nodes |> CompressedArray.unset index, values |> CompressedArray.set index entry, didWeRemove) // Project parent node to hash collision and unset where this node was.
+                        | _ :: _ -> struct (nodes |> CompressedArray.set index (HashCollisionNode(newList)), values, didWeRemove)
+                        | [] -> failwithf "This should never happen; hash collision nodes should always have more than one entry"      
+                
+                // This decides the new parent node minimally required based on child node end state.
+                match nodeValueList |> CompressedArray.count, newValuesList |> CompressedArray.count with
+                | (0, 1) when not first -> struct (RemoveChildNodeAndPreserveSingleValue newValuesList.Content.[0], didWeRemove)
+                | (0, 1) when first -> struct (NewChildNode (TrieNode(nodeValueList, newValuesList)), didWeRemove) // Root node should always be TrieNode
+                | (0, 0) -> struct (RemoveChildNode, didWeRemove)
+                | (_, _) when not didWeRemove -> struct (NoChange, didWeRemove)
+                | (_, _) -> struct (NewChildNode (TrieNode(nodeValueList, newValuesList)), didWeRemove)
+            
         // Need to start the chain. This is harder since we need knowledge of two levels at once (current + sublevel)
         // This is because deletions on a sub-level can mean we create a different node on the current level.
         let changeAndRemovalStatus =
             match hashMap.RootData with
-            | TrieNode(nodes) -> traverseNodes hashMap.RootData nodes 0
-            | TrieNodeFull(nodes) -> traverseNodes hashMap.RootData (CompressedArray.ofFullArrayAsTransient nodes) 0
-            | TrieNodeOne(nodeIndex, node) ->
-                if nodeIndex = rootIndex
-                then
-                    let subNodesEmulated = CompressedArray.ofSingleElement nodeIndex node
-                    let (struct (childNodeOpt, didWeRemove)) = traverseNodes hashMap.RootData subNodesEmulated 0
-                    match childNodeOpt with
-                    | ValueSome(childNode) -> struct (ValueSome (TrieNodeOne(nodeIndex, childNode)), didWeRemove)
-                    | ValueNone -> struct (ValueNone, didWeRemove)
-                else struct (ValueSome hashMap.RootData, false)
+            | TrieNode(nodes, values) -> traverseNodes true nodes values 0
             | _ -> failwithf "Not expected for other node types to be at root position [RootNode: %A]" hashMap.RootData
 
         match changeAndRemovalStatus with
-        | struct (ValueSome newRootNode, true) -> { CurrentCount = hashMap.CurrentCount - 1; RootData = newRootNode; }
-        | struct (ValueNone, true) -> { CurrentCount = 0; RootData = TrieNode(CompressedArray.empty); }
+        | struct (NewChildNode newRootNode, true) -> { CurrentCount = hashMap.CurrentCount - 1; RootData = newRootNode; }
+        | struct (RemoveChildNode, true) -> { CurrentCount = 0; RootData = TrieNode(CompressedArray.empty, CompressedArray.empty); }
+        | struct (NoChange, false) -> hashMap
         | struct (_, false) -> hashMap // If no removal then no change required (unlike Add where replace could occur).
+        | struct (NoChange, true) -> failwithf "Should never occur"
+        | struct (RemoveChildNodeAndPreserveSingleValue _, _) -> failwith "Should never occur at root node"
 
     let public count hashMap = hashMap.CurrentCount
 
     let public toSeq (hashMap: HashTrieRoot<_>) =
         let rec yieldNodes node = seq {
             match node with
-            | TrieNode(nodes) -> for node in nodes.Content do yield! yieldNodes node
-            | TrieNodeFull(nodes) -> for node in nodes do yield! yieldNodes node
-            | TrieNodeOne(_, subNode) -> yield! yieldNodes subNode
-            | EntryNode entry -> yield entry
+            | TrieNode(nodes, values) -> 
+                for values in values.Content do yield values
+                for node in nodes.Content do yield! yieldNodes node
             | HashCollisionNode entries -> for entry in entries do yield entry
         }
 
@@ -345,7 +302,7 @@ module internal HashTrie =
 
     [<GeneralizableValue>]
     let empty< 'tk, 'eq when 'eq : (new : unit -> 'eq)> : HashTrieRoot< ^tk> =
-        { CurrentCount = 0; RootData = TrieNode(CompressedArray.empty) }
+        { CurrentCount = 0; RootData = TrieNode(CompressedArray.empty, CompressedArray.empty) }
 
     [<Struct>]
     type private ItemToCheckForEquality<'t> =
@@ -372,10 +329,9 @@ module internal HashTrie =
         // Custom recursive that allows us to be O(n) for the equality check mostly, with the exception of the hash check.
         let rec equalsSpecificSeq node = seq {
             match node with
-            | TrieNode(nodes) -> for node in nodes.Content do yield! equalsSpecificSeq node
-            | TrieNodeFull(nodes) -> for node in nodes do yield! equalsSpecificSeq node
-            | TrieNodeOne(_, subNode) -> yield! equalsSpecificSeq subNode
-            | EntryNode entry -> yield SingleItem entry
+            | TrieNode(nodes, values) -> 
+                for value in values.Content do yield SingleItem value
+                for node in nodes.Content do yield! equalsSpecificSeq node
             | HashCollisionNode entries -> yield ListOfItems entries
         }
 
@@ -398,6 +354,5 @@ module internal HashTrie =
                 else true
 
             recurseRec()
-
 
         h1.CurrentCount = h2.CurrentCount && recurse (equalsSpecificSeq h1.RootData) (equalsSpecificSeq h2.RootData)

--- a/src/FSharp.HashCollections/HamtImpl.fs
+++ b/src/FSharp.HashCollections/HamtImpl.fs
@@ -7,8 +7,8 @@ open System.Linq
 /// Underlying Hash Trie implementation for other collections.
 module internal HashTrie =
 
-    let [<Literal>] PartitionSize = 6
-    let [<Literal>] PartitionMask = 0b111111
+    let [<Literal>] PartitionSize = 5
+    let [<Literal>] PartitionMask = 0b11111
     let [<Literal>] MaxShiftValue = 32 // Partition Size amount of 1 bits
 
     let inline getIndexNoShift shiftedHash = shiftedHash &&& PartitionMask

--- a/src/FSharp.HashCollections/InternalTypes.fs
+++ b/src/FSharp.HashCollections/InternalTypes.fs
@@ -4,13 +4,18 @@ open System.Collections.Generic
 open System.Runtime.CompilerServices
 open System
 
-type internal HashTrieNode<'tk> =
-    | TrieNode of nodes: CompressedArray<HashTrieNode<'tk>> * entries: CompressedArray<'tk>
+type internal TrieNodeContent<'tk> = 
+    { Nodes: CompressedArray<HashTrieNode<'tk>>
+      Entries: CompressedArray<'tk> }
+    static member inline Empty = { Nodes = CompressedArray.empty; Entries = CompressedArray.empty }
+
+and [<Struct>] internal HashTrieNode<'tk> =
+    | TrieNode of TrieNodeContent<'tk>
     | HashCollisionNode of entries: 'tk list
 
 type [<Struct>] internal HashTrieRoot<'tnode> = {
     CurrentCount: int32
-    RootData: HashTrieNode<'tnode>
+    RootData: TrieNodeContent<'tnode>
 }
 
 module internal HelperFunctions =

--- a/src/FSharp.HashCollections/InternalTypes.fs
+++ b/src/FSharp.HashCollections/InternalTypes.fs
@@ -5,10 +5,7 @@ open System.Runtime.CompilerServices
 open System
 
 type internal HashTrieNode<'tk> =
-    | TrieNodeFull of nodes: HashTrieNode<'tk> array
-    | TrieNode of nodes: CompressedArray<HashTrieNode<'tk>>
-    | TrieNodeOne of index: int * node: HashTrieNode<'tk>
-    | EntryNode of entry: 'tk
+    | TrieNode of nodes: CompressedArray<HashTrieNode<'tk>> * entries: CompressedArray<'tk>
     | HashCollisionNode of entries: 'tk list
 
 type [<Struct>] internal HashTrieRoot<'tnode> = {

--- a/test/FSharp.HashCollections.Benchmarks/AddBenchmark.fs
+++ b/test/FSharp.HashCollections.Benchmarks/AddBenchmark.fs
@@ -112,8 +112,8 @@ type AddBenchmark() =
     [<GlobalSetup(Target = "AddToFsharpxChampMap")>]
     member this.SetupAddToFsharpxChampMap() = 
         this.PrepData()
-        this.OfSeqSystemCollectionsImmutableMap()
-        if systemImmutableMap.Count <> this.CollectionSize then failwithf "Not properly initialised"
+        this.OfSeqFsharpxChampMap()
+        if fsharpXChampMap.Count <> this.CollectionSize then failwithf "Not properly initialised"
 
     [<Benchmark(OperationsPerInvoke = OperationsPerInvoke)>]
     member this.AddToFsharpxChampMap() =

--- a/test/FSharp.HashCollections.Benchmarks/AddBenchmark.fs
+++ b/test/FSharp.HashCollections.Benchmarks/AddBenchmark.fs
@@ -1,25 +1,26 @@
 namespace FSharp.HashCollections.Benchmarks
 
 open System
-open FSharp.HashCollections
 open BenchmarkDotNet.Attributes
-open BenchmarkDotNet.Running
-open FSharpx.Collections
 open System.Collections.Generic
-open ImTools
 
 module private AddBenchmarkConstants = 
     let [<Literal>] OperationsPerInvoke = 50
 open AddBenchmarkConstants
 
-type AddBenchmark() = 
+open FSharp.HashCollections
+open FSharpx.Collections.Experimental
+open FSharpx.Collections
 
-    let mutable hashMap = FSharp.HashCollections.HashMap.empty
+type AddBenchmark() = 
+    
+    let mutable hashMap = HashMap.empty
     let mutable fsharpMap = Map.empty
     let mutable fsharpDataAdaptiveMap = FSharp.Data.Adaptive.HashMap.Empty
     let mutable fsharpXHashMap = FSharpx.Collections.PersistentHashMap.empty
     let mutable systemImmutableMap = System.Collections.Immutable.ImmutableDictionary.Empty
     let mutable fsharpXChampMap = FSharpx.Collections.Experimental.ChampHashMap<int, int>()
+    let mutable languageExtMap = LanguageExt.HashMap.Empty
     let mutable preppedData = Array.zeroCreate 0
 
     let elementsToAdd = 
@@ -57,13 +58,13 @@ type AddBenchmark() =
     [<GlobalSetup(Target = "AddHashMap")>] 
     member this.SetupAddHashMap() = 
         this.PrepData()
-        hashMap <- FSharp.HashCollections.HashMap.ofSeq preppedData
+        hashMap <- HashMap.ofSeq preppedData
         if hashMap |> HashMap.count <> this.CollectionSize then failwithf "Not properly initialised"
 
     [<Benchmark(OperationsPerInvoke = OperationsPerInvoke)>]
     member this.AddHashMap() =
         let mutable hashMap = hashMap
-        for i in elementsToAdd do hashMap <- hashMap |> FSharp.HashCollections.HashMap.add i.Key i.Value
+        for i in elementsToAdd do hashMap <- hashMap |> HashMap.add i.Key i.Value
 
     [<GlobalSetup(Target = "AddToFSharpMap")>]  
     member this.SetupAddToFSharpMap() = 
@@ -85,7 +86,8 @@ type AddBenchmark() =
     [<Benchmark(OperationsPerInvoke = OperationsPerInvoke)>]
     member this.AddToFSharpAdaptiveMap() =
         let mutable fsharpDataAdaptiveMap = fsharpDataAdaptiveMap
-        for i in elementsToAdd do fsharpDataAdaptiveMap <- fsharpDataAdaptiveMap |> FSharp.Data.Adaptive.HashMap.add i.Key i.Value
+        for i in elementsToAdd do 
+            fsharpDataAdaptiveMap <- fsharpDataAdaptiveMap.Add(i.Key, i.Value)
 
     [<GlobalSetup(Target = "AddToFSharpXMap")>] 
     member this.SetupAddToFSharpXMap() = 
@@ -96,7 +98,7 @@ type AddBenchmark() =
     [<Benchmark(OperationsPerInvoke = OperationsPerInvoke)>]
     member this.AddToFSharpXMap() =
         let mutable fsharpXHashMap = fsharpXHashMap
-        for i in elementsToAdd do fsharpXHashMap <- fsharpXHashMap |> FSharpx.Collections.PersistentHashMap.add i.Key i.Value
+        for i in elementsToAdd do fsharpXHashMap <- fsharpXHashMap |> PersistentHashMap.add i.Key i.Value
 
     [<GlobalSetup(Target = "AddToSystemCollectionsImmutableMap")>]
     member this.SetupAddToSystemCollectionsImmutableMap() = 
@@ -107,7 +109,7 @@ type AddBenchmark() =
     [<Benchmark(OperationsPerInvoke = OperationsPerInvoke)>]
     member this.AddToSystemCollectionsImmutableMap() =
         let mutable systemImmutableMap = systemImmutableMap
-        for i in elementsToAdd do systemImmutableMap <- systemImmutableMap.Add(i.Key, i.Value)
+        for i in elementsToAdd do systemImmutableMap <- systemImmutableMap.SetItem(i.Key, i.Value)
 
     [<GlobalSetup(Target = "AddToFsharpxChampMap")>]
     member this.SetupAddToFsharpxChampMap() = 
@@ -118,10 +120,22 @@ type AddBenchmark() =
     [<Benchmark(OperationsPerInvoke = OperationsPerInvoke)>]
     member this.AddToFsharpxChampMap() =
         let mutable fsharpXChampMap = fsharpXChampMap
-        for i in elementsToAdd do fsharpXChampMap <- FSharpx.Collections.Experimental.ChampHashMap.add fsharpXChampMap i.Key i.Value
+        for i in elementsToAdd do fsharpXChampMap <- ChampHashMap.add fsharpXChampMap i.Key i.Value
+
+    [<GlobalSetup(Target = "AddToLangExtMap")>]
+    member this.SetupAddToLangExtMap() = 
+        this.PrepData()
+        this.OfSeqLangExtMap()
+        if languageExtMap.Count <> this.CollectionSize then failwithf "Not properly initialised"
+
+    [<Benchmark(OperationsPerInvoke = OperationsPerInvoke)>]
+    member this.AddToLangExtMap() =
+        let mutable langExtMap = languageExtMap
+        for i in elementsToAdd do 
+            langExtMap <- langExtMap.AddOrUpdate(i.Key, i.Value)
 
     // OfSeq helpers
-    member this.OfSeqHashMap() = hashMap <- FSharp.HashCollections.HashMap.ofSeq preppedData
+    member this.OfSeqHashMap() = hashMap <- HashMap.ofSeq preppedData
 
     member this.OfSeqFSharpXMap() =
         fsharpXHashMap <- FSharpx.Collections.PersistentHashMap.ofSeq (preppedData |> Seq.map (fun (KeyValue(kv)) -> kv))
@@ -132,3 +146,5 @@ type AddBenchmark() =
     member this.OfSeqSystemCollectionsImmutableMap() = systemImmutableMap <- System.Collections.Immutable.ImmutableDictionary.CreateRange(preppedData)
 
     member this.OfSeqFsharpxChampMap() = fsharpXChampMap <- preppedData |> FSharpx.Collections.Experimental.ChampHashMap.ofSeq (fun x -> x.Key) (fun x -> x.Value)
+
+    member this.OfSeqLangExtMap() = languageExtMap <- languageExtMap.AddRange preppedData

--- a/test/FSharp.HashCollections.Benchmarks/BenchmarkProgram.fs
+++ b/test/FSharp.HashCollections.Benchmarks/BenchmarkProgram.fs
@@ -4,6 +4,6 @@ open BenchmarkDotNet.Running
 
 [<EntryPoint>]
 let main argv =
-    let summary = BenchmarkRunner.Run(typeof<ReadBenchmarks>.Assembly)
+    let summary = BenchmarkSwitcher.FromAssembly(typeof<ReadBenchmarks>.Assembly).Run(argv)
     0
 

--- a/test/FSharp.HashCollections.Benchmarks/BenchmarkProgram.fs
+++ b/test/FSharp.HashCollections.Benchmarks/BenchmarkProgram.fs
@@ -4,6 +4,6 @@ open BenchmarkDotNet.Running
 
 [<EntryPoint>]
 let main argv =
-    let summary = BenchmarkRunner.Run(typeof<AddBenchmark>.Assembly)
+    let summary = BenchmarkRunner.Run(typeof<ReadBenchmarks>.Assembly)
     0
 

--- a/test/FSharp.HashCollections.Benchmarks/FSharp.HashCollections.Benchmarks.fsproj
+++ b/test/FSharp.HashCollections.Benchmarks/FSharp.HashCollections.Benchmarks.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -28,6 +28,7 @@
     <PackageReference Include="FSharpX.Collections" Version="3.0.1" />
     <PackageReference Include="FSharpx.Collections.Experimental" Version="3.0.1" />
     <PackageReference Include="ImTools.dll" Version="1.0.0" />
+    <PackageReference Include="LanguageExt.FSharp" Version="4.2.9" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
   </ItemGroup>
 

--- a/test/FSharp.HashCollections.Benchmarks/OfSeqBenchmark.fs
+++ b/test/FSharp.HashCollections.Benchmarks/OfSeqBenchmark.fs
@@ -9,7 +9,7 @@ open System.Collections.Generic
 open ImTools
 
 type OfSeqBenchmark() = 
-
+    
     let mutable hashMap = FSharp.HashCollections.HashMap.empty
     let mutable fsharpMap = Map.empty
     let mutable fsharpDataAdaptiveMap = FSharp.Data.Adaptive.HashMap.Empty
@@ -17,7 +17,6 @@ type OfSeqBenchmark() =
     let mutable systemImmutableMap = System.Collections.Immutable.ImmutableDictionary.Empty
     let mutable fsharpXChampMap = FSharpx.Collections.Experimental.ChampHashMap<int, int>()
     let mutable preppedData = Array.zeroCreate 0
-
 
     [<Params(1000, 100_000, 500_000, 750_000, 1_000_000, 5_000_000, 10_000_000)>]
     member val public CollectionSize = 0 with get, set
@@ -63,3 +62,6 @@ type OfSeqBenchmark() =
 
     [<Benchmark>]
     member this.OfSeqFSharpxChampMap() = fsharpXChampMap <- preppedData |>  FSharpx.Collections.Experimental.ChampHashMap.ofSeq (fun x -> x.Key) (fun x -> x.Value)
+
+    [<Benchmark>]
+    member this.OfSeqLangExtMap() = LanguageExt.HashMap.Empty.AddRange(preppedData)

--- a/test/FSharp.HashCollections.Benchmarks/ReadBenchmark.fs
+++ b/test/FSharp.HashCollections.Benchmarks/ReadBenchmark.fs
@@ -1,15 +1,13 @@
 namespace FSharp.HashCollections.Benchmarks
 
-open System
-open FSharp.HashCollections
 open BenchmarkDotNet.Attributes
-open BenchmarkDotNet.Running
-open FSharpx.Collections
-open ImTools
 
 module private ReadBenchmarkConstants =
     let [<Literal>] OperationsPerInvokeInt = 100000
 open ReadBenchmarkConstants
+
+open FSharp.HashCollections
+open FSharpx.Collections.Experimental
 
 type ReadBenchmarks() =
 
@@ -19,13 +17,14 @@ type ReadBenchmarks() =
     let mutable fsharpXHashMap = FSharpx.Collections.PersistentHashMap.empty
     let mutable systemImmutableMap = System.Collections.Immutable.ImmutableDictionary.Empty
     let mutable fsharpDataAdaptiveMap = FSharp.Data.Adaptive.HashMap.Empty
-    let mutable fsharpXChampMap = FSharpx.Collections.Experimental.ChampHashMap<int32, int32>()
+    let mutable fsharpXChampMap: FSharpx.Collections.Experimental.ChampHashMap<_, _> = FSharpx.Collections.Experimental.ChampHashMap<int32, int32>()
+    let mutable languageExtMap = LanguageExt.HashMap.Empty
 
     let mutable keyToLookup = Array.zeroCreate OperationsPerInvokeInt
     let mutable dummyBufferVOption = Array.zeroCreate OperationsPerInvokeInt
     let mutable dummyBufferOption = Array.zeroCreate OperationsPerInvokeInt
     let mutable dummyBufferNoOption = Array.zeroCreate OperationsPerInvokeInt
-    let randomGen = Random()
+    let randomGen = System.Random()
 
     [<Params(10, 100, 1000, 100_000, 500_000, 750_000, 1_000_000, 5_000_000, 10_000_000)>]
     member val public CollectionSize = 0 with get, set
@@ -36,7 +35,7 @@ type ReadBenchmarks() =
 
     [<GlobalSetup(Target = "GetHashMap")>]
     member this.SetupHashMapData() =
-        hashMapData <- HashMap.empty
+        hashMapData <- FSharp.HashCollections.HashMap.empty
         for i = 0 to this.CollectionSize - 1 do
             hashMapData <- hashMapData |> HashMap.add i i
         this.SetupKeyToLookup()
@@ -59,7 +58,7 @@ type ReadBenchmarks() =
     member this.SetupFSharpXMapData() =
         fsharpXHashMap <- FSharpx.Collections.PersistentHashMap.empty
         for i = 0 to this.CollectionSize - 1 do
-            fsharpXHashMap <- fsharpXHashMap |> FSharpx.Collections.PersistentHashMap.add i i
+            fsharpXHashMap <- fsharpXHashMap.Add(i, i)
         this.SetupKeyToLookup()
 
     [<GlobalSetup(Target = "GetSystemCollectionsImmutableMap")>]
@@ -80,14 +79,21 @@ type ReadBenchmarks() =
     member this.SetupFSharpXChampMap() =
         fsharpXChampMap <- FSharpx.Collections.Experimental.ChampHashMap<int, int>()
         for i = 0 to this.CollectionSize - 1 do
-            fsharpXChampMap <- FSharpx.Collections.Experimental.ChampHashMap.add fsharpXChampMap i i
+            fsharpXChampMap <- ChampHashMap.add fsharpXChampMap i i
+        this.SetupKeyToLookup()
+
+    [<GlobalSetup(Target = "GetLangExtMap")>]
+    member this.SetupLangExtMap() =
+        languageExtMap <- LanguageExt.HashMap.Empty
+        for i = 0 to this.CollectionSize - 1 do
+            languageExtMap <- languageExtMap.Add(i, i)
         this.SetupKeyToLookup()
 
     [<Benchmark(OperationsPerInvoke = OperationsPerInvokeInt)>]
     member _.GetHashMap() =
         let mutable i = 0
         for k in keyToLookup do
-            dummyBufferVOption.[i] <- hashMapData |> HashMap.tryFind k
+            dummyBufferVOption.[i] <- hashMapData |> FSharp.HashCollections.HashMap.tryFind k
             i <- i + 1
 
     [<Benchmark(OperationsPerInvoke = OperationsPerInvokeInt)>]
@@ -134,4 +140,11 @@ type ReadBenchmarks() =
         let mutable i = 0
         for k in keyToLookup do
             dummyBufferOption.[i] <- FSharpx.Collections.Experimental.ChampHashMap.tryGetValue fsharpXChampMap k 
+            i <- i + 1
+
+    [<Benchmark(OperationsPerInvoke = OperationsPerInvokeInt)>]
+    member _.GetLangExtMap() =
+        let mutable i = 0
+        for k in keyToLookup do
+            dummyBufferNoOption.[i] <- languageExtMap.[k]
             i <- i + 1

--- a/test/FSharp.HashCollections.Unit/HashSetTest.fs
+++ b/test/FSharp.HashCollections.Unit/HashSetTest.fs
@@ -115,6 +115,30 @@ let generateLargeSizeMapOfSeqTest() =
       let resultSeq = resultSet |> HashSet.toSeq |> Seq.toArray |> Array.sort
       Expect.equal resultSeq testData "Array data not the same")
 
+let largeSetAddAllThenRemoveAllIsEmpty() =
+  testCase
+    "Large set test then remove all results in empty"
+    (fun () ->
+      let testDataSize = 5000000
+      let testData = Array.init testDataSize id
+      let mutable resultSet = testData |> Array.fold (fun s t -> s |> HashSet.add t) HashSet.empty
+      let resultSeq = resultSet |> HashSet.toSeq |> Seq.toArray |> Array.sort
+
+      Expect.equal resultSeq testData "Array data not the same"
+      Expect.equal testDataSize (HashSet.count resultSet) "Set not empty"
+      Expect.isTrue (resultSet |> HashSet.contains (testDataSize / 2)) "Value not found"
+      Expect.isTrue (resultSet |> HashSet.contains 1) "Value not found (1)"
+      Expect.isTrue (resultSet |> HashSet.contains (testDataSize - 1))  "Value not found (Last Value)"
+
+      for k in testData do resultSet <- resultSet |> HashSet.remove k
+
+      Expect.equal 0 (HashSet.count resultSet) "Set not empty"
+      Expect.isFalse (resultSet |> HashSet.contains (testDataSize / 2)) "Value still found"
+      Expect.isFalse (resultSet |> HashSet.contains 1) "Value still found (1)"
+      Expect.isFalse (resultSet |> HashSet.contains (5000000 - 1)) "Value still found (Last Value)"
+      Expect.equal resultSet HashSet.empty "HashSet should be empty"
+    )
+
 let intersectionEquilvalentToReference (hsOne: list<Guid>) (hsTwo: list<Guid>) =
   let referenceSet = System.Collections.Generic.HashSet(hsOne)
   referenceSet.IntersectWith(hsTwo)
@@ -214,6 +238,8 @@ let [<Tests>] tests =
           generateLargeSizeMapTest()
 
           generateLargeSizeMapOfSeqTest()
+
+          largeSetAddAllThenRemoveAllIsEmpty()
 
           buildPropertyTest
             "Set and HashSet behave the same on Add and Remove"


### PR DESCRIPTION
This is an attempt to see the effect on performance if we remove nodes and bring the values up to avoid recursion for the entry node taking some inspiration from CHAMP but with a more .NET flavor taking advantage of some of F#'s features on top.

Current benchmarks below. For smaller collections below 1,000,000 significantly faster in many cases. As per comments this makes us the fastest in all cases across every collection in the .NET ecosystem I could find for the general lookup case. The very big collections grow slightly but not as much of a concern % wise. This is especially true around the 500,000 to 1,000,000 range.

Seeing 3.8GB go down to 2.1GB in memory consumption using a quick FSX script storing 30,000,000 elements with a HashMap<int, string> (string being converted from the int key) entry. So it is more memory efficient as well.

``` ini

BenchmarkDotNet=v0.13.1, OS=arch 
AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.110
  [Host]     : .NET 6.0.10 (6.0.1022.51301), X64 RyuJIT DEBUG
  DefaultJob : .NET 6.0.10 (6.0.1022.51301), X64 RyuJIT


```
|                           Method | CollectionSize |        Mean |    Error |   StdDev |
|--------------------------------- |--------------- |------------:|---------:|---------:|
|                       **GetHashMapCurrent** |             **10** |    **11.29 ns** | **0.092 ns** | **0.086 ns** |
|                       **GetHashMapNew** |             **10** |    **10.65 ns** | **0.058 ns** | **0.054 ns** |
|                       **GetHashMapCurrent** |            **100** |    **16.69 ns** | **0.135 ns** | **0.126 ns** |
|                       **GetHashMapNew** |            **100** |    **11.05 ns** | **0.066 ns** | **0.062 ns** |
|                       **GetHashMapCurrent** |           **1000** |    **12.53 ns** | **0.120 ns** | **0.101 ns** |
|                       **GetHashMapNew** |           **1000** |    **11.07 ns** | **0.071 ns** | **0.066 ns** |
|                       **GetHashMapCurrent** |         **100000** |    **27.60 ns** | **0.239 ns** | **0.223 ns** |
|                       **GetHashMapNew** |         **100000** |    **30.42 ns** | **0.274 ns** | **0.257 ns** |
|                       **GetHashMapCurrent** |         **500000** |    **75.84 ns** | **0.737 ns** | **0.689 ns** |
|                       **GetHashMapNew** |         **500000** |    **32.58 ns** | **0.302 ns** | **0.282 ns** |
|                       **GetHashMapCurrent** |         **750000** |   **108.36 ns** | **0.605 ns** | **0.506 ns** |
|                       **GetHashMapNew** |         **750000** |    **35.01 ns** | **0.387 ns** | **0.343 ns** |
|                       **GetHashMapCurrent** |        **1000000** |   **115.40 ns** | **0.202 ns** | **0.169 ns** |
|                       **GetHashMapNew** |        **1000000** |    **38.45 ns** | **0.111 ns** | **0.086 ns** |
|                       **GetHashMapCurrent** |        **5000000** |   **144.12 ns** | **0.331 ns** | **0.294 ns** |
|                       **GetHashMapNew** |        **5000000** |   **176.51 ns** | **0.731 ns** | **0.684 ns** |
|                       **GetHashMapCurrent** |       **10000000** |   **163.24 ns** | **0.788 ns** | **0.737 ns** |
|                       **GetHashMapNew** |       **10000000** |   **178.63 ns** | **0.561 ns** | **0.524 ns** |

``` ini